### PR TITLE
Add Windows deployment

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -1,0 +1,1 @@
+mv target/x86_64-pc-windows-gnu/release/av-metrics-tool.exe ./

--- a/.github/workflows/deploy_windows.yml
+++ b/.github/workflows/deploy_windows.yml
@@ -1,0 +1,34 @@
+name: Deploy av_metrics_tool for Windows
+
+on: release
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Install mingw-w64 and rust specific target
+      run: |
+        sudo apt-get install mingw-w64
+        rustup target add x86_64-pc-windows-gnu
+    - name: Set rust for cross-compilation
+      env:
+          TARGET: rustlib/x86_64-pc-windows-gnu/lib/
+      run: |
+        printf "[target.x86_64-pc-windows-gnu] \n \
+                linker = \"/usr/bin/x86_64-w64-mingw32-gcc\" \n \
+                ar = \"/usr/x86_64-w64-mingw32/ar\"" > $HOME/.cargo/config
+        # https://github.com/rust-lang/rust/issues/48272#issuecomment-429596397
+        cd $HOME/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/$TARGET
+        mv crt2.o crt2.o.bak
+        cp /usr/x86_64-w64-mingw32/lib/crt2.o ./
+    - name: Cross-compile
+      run: |
+          cargo build --release --target x86_64-pc-windows-gnu
+    - name: Upload binary
+      uses: skx/github-action-publish-binaries@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        args: 'av-metrics-tool.exe'


### PR DESCRIPTION
Append `av-metrics-tools.exe` to a release. This fixes #7 

I was constrained to cross-compile it because the `github-action-publish-binaries` works only on Linux.

Thanks for your review! 