### PR TITLE
Trigger the release action only with the created event

### DIFF
--- a/.github/workflows/deploy-windows.yml
+++ b/.github/workflows/deploy-windows.yml
@@ -1,6 +1,8 @@
 name: Deploy av_metrics_tool for Windows
 
-on: release
+on:
+  release:
+    types: [created]
 
 jobs:
   upload:


### PR DESCRIPTION
Only when a new release is created, the release action is triggered, as such the other release's events are not considered.

In addition, rename the file to be more consistent with the CI filename.