### PR TITLE
Parallelize frame processing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,8 +74,8 @@ jobs:
         toolchain: stable
         override: true
     - name: Build
-      run: cargo build --all-features --tests --benches
+      run: cargo build --release --all-features --tests --benches
     - name: Run tests
-      run: cargo test --all-features
+      run: cargo test --release --all-features
     - name: Generate docs
-      run: cargo doc --all-features --no-deps
+      run: cargo doc --release --all-features --no-deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "lab 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
  "y4m 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -14,6 +14,7 @@ lab = "0.7.2"
 libc = "0.2"
 num-traits = "0.2"
 serde = { version = "1", features = ["derive"], optional = true }
+rayon = { version = "1.2.1", optional = true }
 y4m = { version = "0.4", optional = true }
 
 [dev-dependencies]
@@ -21,7 +22,7 @@ criterion = "0.3"
 
 [features]
 default = ["y4m-decode"]
-decode = []
+decode = ["rayon"]
 y4m-decode = ["y4m", "decode"]
 bench = []
 

--- a/av_metrics/src/lib.rs
+++ b/av_metrics/src/lib.rs
@@ -12,6 +12,8 @@ extern crate err_derive;
 #[macro_use]
 extern crate itertools;
 
+extern crate rayon;
+
 pub mod video;
 
 #[cfg(cargo_c)]

--- a/av_metrics/src/video/decode/mod.rs
+++ b/av_metrics/src/video/decode/mod.rs
@@ -12,7 +12,7 @@ pub use self::y4m::*;
 /// Currently, y4m decoding support using the `y4m` crate is built-in
 /// to this crate. This trait is extensible so users may implement
 /// their own decoders.
-pub trait Decoder {
+pub trait Decoder: Send {
     /// Read the next frame from the input video.
     ///
     /// Expected to return `Err` if the end of the video is reached.

--- a/av_metrics/src/video/decode/y4m.rs
+++ b/av_metrics/src/video/decode/y4m.rs
@@ -38,7 +38,7 @@ fn copy_from_raw_u8<T: Pixel>(source: &[u8]) -> Vec<T> {
     }
 }
 
-impl<R: Read> Decoder for y4m::Decoder<'_, R> {
+impl<R: Read + Send> Decoder for y4m::Decoder<'_, R> {
     fn read_video_frame<T: Pixel>(&mut self) -> Result<FrameInfo<T>, ()> {
         let bit_depth = self.get_bit_depth();
         let (chroma_sampling, chroma_sample_pos) = get_chroma_sampling(self);


### PR DESCRIPTION
This PR fixes #10 

Starting from the [thread-videos](https://github.com/rust-av/av-metrics/tree/thread-videos) branch, I've parallelized the frame processing. Unfortunately, I can't see any notable difference compared to the sequential version. Do you know what could be the problem @shssoichiro?

Thanks in advance for your review! :) 