### PR TITLE
Update cargo-c process

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -41,13 +41,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
     - name: Install cargo-c
       run: |
         cargo install cargo-c
     - name: Run cargo-c
       run: |
-        cargo cinstall --all-features \
-                       --prefix=$HOME/av_metrics_deploy
+        cargo cinstall --prefix=$HOME/av_metrics_deploy
     - name: Build cargo-c tests
       run: |
         export PKG_CONFIG_PATH=$HOME/av_metrics_deploy/lib/pkgconfig

--- a/av_metrics/src/capi.rs
+++ b/av_metrics/src/capi.rs
@@ -50,7 +50,6 @@ fn convert_c_string_into_path(c_buf: *const c_char) -> PathBuf {
     Path::new(c_str.to_str().unwrap()).to_path_buf()
 }
 
-#[inline(always)]
 fn run_metric(
     path1: *const c_char,
     path2: *const c_char,
@@ -82,7 +81,6 @@ fn run_metric(
     (null(), -1.0)
 }
 
-#[inline(always)]
 fn run_video_metric<P: AsRef<Path>>(
     path1: P,
     container1: VideoContainer,
@@ -129,7 +127,6 @@ fn run_video_metric<P: AsRef<Path>>(
     (null(), -1.0)
 }
 
-#[inline(always)]
 fn run_frame_metric<P: AsRef<Path>>(
     path1: P,
     container1: VideoContainer,


### PR DESCRIPTION
This should fix the `cargo-c` discontinuity issue.

- Remove the `inline(always)` attributes
- Install the latest `Rust` version
- Remove the `--all-features` option from `cargo c-install`

Thanks in advance for your review! :)