### PR TITLE
capi: Expose frame buffer API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "av-metrics"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "criterion 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 opt-level = 1
 
 [replace]
-"av-metrics:0.5.0" = { path = "av_metrics" }
+"av-metrics:0.6.0" = { path = "av_metrics" }

--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "av-metrics"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Josh Holmer <jholmer.in@gmail.com>"]
 edition = "2018"
 description = "A collection of algorithms for measuring audio/video metrics"

--- a/av_metrics/cbindgen.toml
+++ b/av_metrics/cbindgen.toml
@@ -6,5 +6,14 @@ tab_width = 4
 style = "Type"
 language = "C"
 
+[parse]
+parse_deps = true
+include = ['av_metrics', 'v_frame']
+
 [export]
 prefix = "AVM"
+item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions"]
+
+[enum]
+rename_variants = "ScreamingSnakeCase"
+prefix_with_name = true

--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -94,6 +94,7 @@ impl ChromaWeight for ChromaSampling {
 
 /// Sample position for subsampled chroma
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
 pub enum ChromaSamplePosition {
     /// The source video transfer function is not signaled. This crate will assume
     /// no transformation needs to be done on this data, but there is a risk of metric


### PR DESCRIPTION
# Notes

Currently untested - I will get to testing this tonight after dinner, and will update the PR text after. It's very likely to explode on 4:0:0.

Comments welcome - it's kinda ugly, but such is C interop.

Also of note is that `Cargo.toml` in the main directory is sitll pointing to av-metrics 0.4.0 for some reason.