### PR TITLE
More multi-thread support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "av-metrics"
 version = "0.5.1"
 dependencies = [
  "criterion",
+ "crossbeam",
  "itertools",
  "lab",
  "libc",
@@ -176,6 +177,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +224,17 @@ dependencies = [
  "maybe-uninit",
  "memoffset",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]

--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -17,7 +17,8 @@ serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1"
 y4m = { version = "0.7", optional = true }
 v_frame = { version = "0.1.0" }
-rayon = "1.3"
+rayon = "1.4"
+crossbeam = "0.7"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/av_metrics/benches/bench.rs
+++ b/av_metrics/benches/bench.rs
@@ -16,7 +16,7 @@ use y4m::Decoder as Y4MDec;
 fn get_video_frame<T: Pixel>(filename: &str) -> FrameInfo<T> {
     let mut file = File::open(filename).unwrap();
     let mut dec = Y4MDec::new(&mut file).unwrap();
-    dec.read_video_frame(&dec.get_video_details()).unwrap()
+    dec.read_video_frame().unwrap()
 }
 
 pub fn psnr_benchmark(c: &mut Criterion) {

--- a/av_metrics/src/video/ciede/mod.rs
+++ b/av_metrics/src/video/ciede/mod.rs
@@ -87,7 +87,7 @@ impl VideoMetric for Ciede2000 {
     type VideoResult = f64;
 
     fn process_frame<T: Pixel>(
-        &mut self,
+        &self,
         frame1: &FrameInfo<T>,
         frame2: &FrameInfo<T>,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {

--- a/av_metrics/src/video/decode/mod.rs
+++ b/av_metrics/src/video/decode/mod.rs
@@ -13,11 +13,11 @@ pub use self::y4m::*;
 /// Currently, y4m decoding support using the `y4m` crate is built-in
 /// to this crate. This trait is extensible so users may implement
 /// their own decoders.
-pub trait Decoder {
+pub trait Decoder: Send + Sync {
     /// Read the next frame from the input video.
     ///
     /// Expected to return `Err` if the end of the video is reached.
-    fn read_video_frame<T: Pixel>(&mut self, cfg: &VideoDetails) -> Result<FrameInfo<T>, ()>;
+    fn read_video_frame<T: Pixel>(&mut self) -> Result<FrameInfo<T>, ()>;
     /// Read a specific frame from the input video
     ///
     /// Expected to return `Err` if the frame is not found.

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -76,7 +76,7 @@ impl VideoMetric for Psnr {
     type VideoResult = PsnrResults;
 
     fn process_frame<T: Pixel>(
-        &mut self,
+        &self,
         frame1: &FrameInfo<T>,
         frame2: &FrameInfo<T>,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {


### PR DESCRIPTION
According to hyperfine  4.03 ± 0.01 times faster on a 20-hw-threads machine.

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `./av-metrics-tool-mt ~/Samples/Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m /tmp/out.y4m` | 111.635 ± 0.260 | 111.451 | 111.819 | 1.00 |
| `./av-metrics-tool-no-mt ~/Samples/Bosphorus_1920x1080_120fps_420_8bit_YUV.y4m /tmp/out.y4m` | 450.062 ± 0.396 | 449.783 | 450.342 | 4.03 ± 0.01 |