### PR TITLE
csv/markdown output

### DIFF
--- a/av_metrics_tool/src/main.rs
+++ b/av_metrics_tool/src/main.rs
@@ -65,9 +65,9 @@ fn main() -> Result<(), String> {
                 .value_name("FILE"),
         )
         .arg(
-            Arg::with_name("OUTPUT")
-                .help("Output to stdout")
-                .long("output")
+            Arg::with_name("QUIET")
+                .help("Do not output to stdout")
+                .long("quiet")
                 .takes_value(false),
         )
         .get_matches();
@@ -96,12 +96,7 @@ fn main() -> Result<(), String> {
             File::create(filename).map_err(|err| err.to_string())?,
         )));
     };
-    if cli.is_present("OUTPUT")
-        || !(cli.is_present("FILE")
-            || cli.is_present("JSON")
-            || cli.is_present("CSV")
-            || cli.is_present("MARKDOWN"))
-    {
+    if !cli.is_present("QUIET") {
         writers.push(OutputType::Stdout(BufWriter::new(std::io::stdout())));
     }
 


### PR DESCRIPTION
This PR adds support for csv and markdown output.

The json output has been modified from 
```
  "msssim": {
    "result": {
      "avg": 18.563123214405696,
      "u": 16.853879623338113,
      "v": 18.864727228134157,
      "y": 19.03903696094473
    }
  }
```
to 
```
  "msssim": {
    "y": 19.03903696094478,
    "u": 16.853879623338145,
    "v": 18.864727228134157,
    "avg": 18.56312321440576
  }
```

If that's a problem, I'll rework it.

Closes: #170 