### PR TITLE
Add a progress indicator to the CLI tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "av-metrics-decoders",
  "clap",
  "console",
+ "indicatif",
  "serde",
  "serde_json",
 ]
@@ -427,6 +428,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +566,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "oorandom"

--- a/av_metrics/src/video/ciede/mod.rs
+++ b/av_metrics/src/video/ciede/mod.rs
@@ -24,12 +24,13 @@ use delta_e::*;
 /// Optionally, `frame_limit` can be set to only compare the first
 /// `frame_limit` frames in each video.
 #[inline]
-pub fn calculate_video_ciede<D: Decoder>(
+pub fn calculate_video_ciede<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<f64, Box<dyn Error>> {
-    Ciede2000::default().process_video(decoder1, decoder2, frame_limit)
+    Ciede2000::default().process_video(decoder1, decoder2, frame_limit, progress_callback)
 }
 
 /// Calculate the CIEDE2000 metric between two video clips. Higher is better.
@@ -38,12 +39,18 @@ pub fn calculate_video_ciede<D: Decoder>(
 /// by tests and benchmarks.
 #[inline]
 #[doc(hidden)]
-pub fn calculate_video_ciede_nosimd<D: Decoder>(
+pub fn calculate_video_ciede_nosimd<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<f64, Box<dyn Error>> {
-    (Ciede2000 { use_simd: false }).process_video(decoder1, decoder2, frame_limit)
+    (Ciede2000 { use_simd: false }).process_video(
+        decoder1,
+        decoder2,
+        frame_limit,
+        progress_callback,
+    )
 }
 
 /// Calculate the CIEDE2000 metric between two video frames. Higher is better.

--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -139,11 +139,12 @@ trait VideoMetric: Send + Sync {
     ///
     /// `frame_fn` is the function to calculate metrics on one frame of the video.
     /// `acc_fn` is the accumulator function to calculate the aggregate metric.
-    fn process_video<D: Decoder>(
+    fn process_video<D: Decoder, F: Fn(usize) + Send>(
         &mut self,
         decoder1: &mut D,
         decoder2: &mut D,
         frame_limit: Option<usize>,
+        progress_callback: F,
     ) -> Result<Self::VideoResult, Box<dyn Error>> {
         if decoder1.get_bit_depth() != decoder2.get_bit_depth() {
             return Err(Box::new(MetricsError::InputMismatch {
@@ -152,9 +153,9 @@ trait VideoMetric: Send + Sync {
         }
 
         if decoder1.get_bit_depth() > 8 {
-            self.process_video_mt::<D, u16>(decoder1, decoder2, frame_limit)
+            self.process_video_mt::<D, u16, F>(decoder1, decoder2, frame_limit, progress_callback)
         } else {
-            self.process_video_mt::<D, u8>(decoder1, decoder2, frame_limit)
+            self.process_video_mt::<D, u8, F>(decoder1, decoder2, frame_limit, progress_callback)
         }
     }
 
@@ -169,11 +170,12 @@ trait VideoMetric: Send + Sync {
         metrics: &[Self::FrameResult],
     ) -> Result<Self::VideoResult, Box<dyn Error>>;
 
-    fn process_video_mt<D: Decoder, P: Pixel>(
+    fn process_video_mt<D: Decoder, P: Pixel, F: Fn(usize) + Send>(
         &mut self,
         decoder1: &mut D,
         decoder2: &mut D,
         frame_limit: Option<usize>,
+        progress_callback: F,
     ) -> Result<Self::VideoResult, Box<dyn Error>> {
         let num_threads = (rayon::current_num_threads() - 1).max(1);
 
@@ -189,6 +191,7 @@ trait VideoMetric: Send + Sync {
                     let frame1 = decoder1.read_video_frame::<P>();
                     let frame2 = decoder2.read_video_frame::<P>();
                     if let (Some(frame1), Some(frame2)) = (frame1, frame2) {
+                        progress_callback(decoded);
                         send.send((frame1, frame2)).unwrap();
                     } else {
                         break;

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -17,12 +17,13 @@ use v_frame::plane::Plane;
 /// from e.g. all black frames, which would
 /// otherwise show a PSNR of infinity.
 #[inline]
-pub fn calculate_video_psnr<D: Decoder>(
+pub fn calculate_video_psnr<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
-    let metrics = Psnr.process_video(decoder1, decoder2, frame_limit)?;
+    let metrics = Psnr.process_video(decoder1, decoder2, frame_limit, progress_callback)?;
     Ok(metrics.psnr)
 }
 
@@ -32,12 +33,13 @@ pub fn calculate_video_psnr<D: Decoder>(
 /// from e.g. all black frames, which would
 /// otherwise show a APSNR of infinity.
 #[inline]
-pub fn calculate_video_apsnr<D: Decoder>(
+pub fn calculate_video_apsnr<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
-    let metrics = Psnr.process_video(decoder1, decoder2, frame_limit)?;
+    let metrics = Psnr.process_video(decoder1, decoder2, frame_limit, progress_callback)?;
     Ok(metrics.apsnr)
 }
 

--- a/av_metrics/src/video/psnr_hvs.rs
+++ b/av_metrics/src/video/psnr_hvs.rs
@@ -16,10 +16,11 @@ use v_frame::plane::Plane;
 
 /// Calculates the PSNR-HVS score between two videos. Higher is better.
 #[inline]
-pub fn calculate_video_psnr_hvs<D: Decoder>(
+pub fn calculate_video_psnr_hvs<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let cweight = Some(
         decoder1
@@ -27,7 +28,7 @@ pub fn calculate_video_psnr_hvs<D: Decoder>(
             .chroma_sampling
             .get_chroma_weight(),
     );
-    PsnrHvs { cweight }.process_video(decoder1, decoder2, frame_limit)
+    PsnrHvs { cweight }.process_video(decoder1, decoder2, frame_limit, progress_callback)
 }
 
 /// Calculates the PSNR-HVS score between two video frames. Higher is better.

--- a/av_metrics/src/video/ssim.rs
+++ b/av_metrics/src/video/ssim.rs
@@ -20,10 +20,11 @@ use v_frame::plane::Plane;
 
 /// Calculates the SSIM score between two videos. Higher is better.
 #[inline]
-pub fn calculate_video_ssim<D: Decoder>(
+pub fn calculate_video_ssim<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let cweight = Some(
         decoder1
@@ -31,7 +32,7 @@ pub fn calculate_video_ssim<D: Decoder>(
             .chroma_sampling
             .get_chroma_weight(),
     );
-    Ssim { cweight }.process_video(decoder1, decoder2, frame_limit)
+    Ssim { cweight }.process_video(decoder1, decoder2, frame_limit, progress_callback)
 }
 
 /// Calculates the SSIM score between two video frames. Higher is better.
@@ -161,10 +162,11 @@ impl VideoMetric for Ssim {
 /// of an image. It is designed to be a more accurate metric
 /// than SSIM.
 #[inline]
-pub fn calculate_video_msssim<D: Decoder>(
+pub fn calculate_video_msssim<D: Decoder, F: Fn(usize) + Send>(
     decoder1: &mut D,
     decoder2: &mut D,
     frame_limit: Option<usize>,
+    progress_callback: F,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let cweight = Some(
         decoder1
@@ -172,7 +174,7 @@ pub fn calculate_video_msssim<D: Decoder>(
             .chroma_sampling
             .get_chroma_weight(),
     );
-    MsSsim { cweight }.process_video(decoder1, decoder2, frame_limit)
+    MsSsim { cweight }.process_video(decoder1, decoder2, frame_limit, progress_callback)
 }
 
 /// Calculates the MSSSIM score between two video frames. Higher is better.

--- a/av_metrics_tests/src/lib.rs
+++ b/av_metrics_tests/src/lib.rs
@@ -32,7 +32,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.5281, result.y);
         assert_metric_eq(36.4083, result.u);
         assert_metric_eq(39.8238, result.v);
@@ -51,7 +51,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(38.6740, result.y);
         assert_metric_eq(47.5219, result.u);
         assert_metric_eq(48.8615, result.v);
@@ -70,7 +70,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.4235, result.y);
         assert_metric_eq(40.1212, result.u);
         assert_metric_eq(43.1900, result.v);
@@ -89,7 +89,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.5421, result.y);
         assert_metric_eq(36.4922, result.u);
         assert_metric_eq(39.8558, result.v);
@@ -108,7 +108,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_apsnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_apsnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.5450, result.y);
         assert_metric_eq(36.4087, result.u);
         assert_metric_eq(39.8244, result.v);
@@ -127,7 +127,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_apsnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_apsnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(38.6741, result.y);
         assert_metric_eq(47.5219, result.u);
         assert_metric_eq(48.8616, result.v);
@@ -146,7 +146,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_apsnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_apsnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.4412, result.y);
         assert_metric_eq(40.1264, result.u);
         assert_metric_eq(43.1943, result.v);
@@ -165,7 +165,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_apsnr::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_apsnr(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(32.5586, result.y);
         assert_metric_eq(36.4923, result.u);
         assert_metric_eq(39.8563, result.v);
@@ -184,7 +184,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr_hvs::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr_hvs(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(34.3227, result.y);
         assert_metric_eq(37.7400, result.u);
         assert_metric_eq(40.5570, result.v);
@@ -203,7 +203,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr_hvs::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr_hvs(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(45.3473, result.y);
         assert_metric_eq(46.3951, result.u);
         assert_metric_eq(45.1177, result.v);
@@ -222,7 +222,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr_hvs::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr_hvs(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(34.1887, result.y);
         assert_metric_eq(38.0190, result.u);
         assert_metric_eq(40.4087, result.v);
@@ -241,7 +241,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_psnr_hvs::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_psnr_hvs(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(34.4843, result.y);
         assert_metric_eq(38.1651, result.u);
         assert_metric_eq(41.0645, result.v);
@@ -260,7 +260,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(13.2572, result.y);
         assert_metric_eq(10.8624, result.u);
         assert_metric_eq(12.8369, result.v);
@@ -279,7 +279,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_msssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_msssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(18.8343, result.y);
         assert_metric_eq(16.6943, result.u);
         assert_metric_eq(18.7662, result.v);
@@ -298,7 +298,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(21.1130, result.y);
         assert_metric_eq(21.9978, result.u);
         assert_metric_eq(22.7898, result.v);
@@ -317,7 +317,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_msssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_msssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(28.6035, result.y);
         assert_metric_eq(28.0332, result.u);
         assert_metric_eq(28.0097, result.v);
@@ -336,7 +336,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(13.2989, result.y);
         assert_metric_eq(14.0089, result.u);
         assert_metric_eq(15.7419, result.v);
@@ -355,7 +355,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_msssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_msssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(18.8897, result.y);
         assert_metric_eq(17.6092, result.u);
         assert_metric_eq(19.2732, result.v);
@@ -374,7 +374,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(13.3603, result.y);
         assert_metric_eq(10.9323, result.u);
         assert_metric_eq(12.8685, result.v);
@@ -393,7 +393,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_msssim::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_msssim(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(19.0390, result.y);
         assert_metric_eq(16.8539, result.u);
         assert_metric_eq(18.8647, result.v);
@@ -412,7 +412,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede_nosimd::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede_nosimd(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(36.2821, result);
     }
 
@@ -428,7 +428,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(36.2821, result);
     }
 
@@ -444,7 +444,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede_nosimd::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede_nosimd(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(43.9618, result);
     }
 
@@ -460,7 +460,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(43.9618, result);
     }
 
@@ -476,7 +476,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede_nosimd::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede_nosimd(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(37.5106, result);
     }
 
@@ -492,7 +492,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(37.5106, result);
     }
 
@@ -508,7 +508,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede_nosimd::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede_nosimd(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(36.3691, result);
     }
 
@@ -524,7 +524,7 @@ mod tests {
             env!("CARGO_MANIFEST_DIR")
         ))
         .unwrap();
-        let result = calculate_video_ciede::<_>(&mut dec1, &mut dec2, None).unwrap();
+        let result = calculate_video_ciede(&mut dec1, &mut dec2, None, |_| ()).unwrap();
         assert_metric_eq(36.3691, result);
     }
 

--- a/av_metrics_tool/Cargo.toml
+++ b/av_metrics_tool/Cargo.toml
@@ -13,6 +13,7 @@ av-metrics = { version = "0.6", features = ["serde"] }
 av-metrics-decoders = "0.1"
 clap = "2.33"
 console = "0.13.0"
+indicatif = "0.15.0"
 serde = "1"
 serde_json = "1"
 


### PR DESCRIPTION
Simple indicator that displays which metric is running and how many frames have been processed.
This is disabled if the program is run in a non-interactive setting or if the --quiet flag is provided.

Closes #195