### PR TITLE
Mark the end of the decoding process

### DIFF
--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -197,6 +197,8 @@ trait VideoMetric: Send + Sync {
                         break;
                     }
                 }
+                // Mark the end of the decoding process
+                progress_callback(usize::MAX);
             });
 
             use rayon::prelude::*;

--- a/av_metrics_tool/src/main.rs
+++ b/av_metrics_tool/src/main.rs
@@ -205,7 +205,9 @@ fn run_video_metrics(
     };
 
     let progress_fn = |frameno: usize| {
-        progress.set_position(frameno as u64);
+        if frameno != usize::MAX {
+            progress.set_position(frameno as u64);
+        }
     };
 
     if metric.is_none() || metric == Some("psnr") {


### PR DESCRIPTION
Add a way to know when the decoding process of the two input videos is finished