### PR TITLE
Add Default trait to PlanarMetrics

### DIFF
--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -117,7 +117,7 @@ impl Default for ChromaSamplePosition {
 
 /// Certain metrics return a value per plane. This struct contains the output
 /// for those metrics per plane, as well as a weighted average of the planes.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct PlanarMetrics {
     /// Metric value for the Y plane.


### PR DESCRIPTION
This PR adds the `Default` trait to the `PlanarMetrics` struct