### PR TITLE
Update metadata to include LICENSE files in published crates

### DIFF
--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "A collection of algorithms for measuring audio/video metrics"
 license = "MIT"
 repository = "https://github.com/rust-av/av-metrics"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 crossbeam = "0.8"

--- a/av_metrics_decoders/Cargo.toml
+++ b/av_metrics_decoders/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Decoders for use with av-metrics"
 license = "MIT"
 repository = "https://github.com/rust-av/av-metrics"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/av_metrics_tool/Cargo.toml
+++ b/av_metrics_tool/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "A CLI tool for measuring audio/video metrics"
 license = "MIT"
 repository = "https://github.com/rust-av/av-metrics"
-include = ["src/**/*"]
+include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 av-metrics = { version = "0.9", features = ["serde"] }


### PR DESCRIPTION
This is a follow-up for issue #215 and commit https://github.com/rust-av/av-metrics/commit/c7e0a7d41a9611d414deb6e14720f34d16d43169 . It looks like it was missed that the crates have `include = ["src/**/*"]` in their Cargo.toml files, which made the previous change ineffective - it resulted in LICENSE files being included in the git repository, but due to the restrictive `include` setting in Cargo.toml files in this workspace, they never ended up in published crates.