### PR TITLE
Bump av-metrics-decoders in other av-metrics crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,18 +86,6 @@ dependencies = [
 
 [[package]]
 name = "av-metrics-decoders"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347427ab632003ebaba20436bb60584dd396f50d4c0093044dcd6191991274e3"
-dependencies = [
- "anyhow",
- "av-metrics",
- "ffmpeg-the-third",
- "y4m",
-]
-
-[[package]]
-name = "av-metrics-decoders"
 version = "0.3.1"
 dependencies = [
  "anyhow",
@@ -112,7 +100,7 @@ name = "av-metrics-tests"
 version = "0.0.1"
 dependencies = [
  "av-metrics",
- "av-metrics-decoders 0.2.3",
+ "av-metrics-decoders",
 ]
 
 [[package]]
@@ -120,7 +108,7 @@ name = "av-metrics-tool"
 version = "0.9.1"
 dependencies = [
  "av-metrics",
- "av-metrics-decoders 0.3.1",
+ "av-metrics-decoders",
  "clap",
  "console",
  "indicatif",
@@ -140,7 +128,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "lazycell",
-  "proc-macro2",
+ "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
@@ -623,12 +611,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ name = "av-metrics-tool"
 version = "0.9.1"
 dependencies = [
  "av-metrics",
- "av-metrics-decoders 0.2.3",
+ "av-metrics-decoders 0.3.1",
  "clap",
  "console",
  "indicatif",

--- a/av_metrics_tests/Cargo.toml
+++ b/av_metrics_tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 av-metrics = { version = "0.9", features = ["serde"] }
-av-metrics-decoders = "0.2.1"
+av-metrics-decoders = "0.3.1"
 
 [features]
 default = ["y4m"]

--- a/av_metrics_tests/src/lib.rs
+++ b/av_metrics_tests/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    #![allow(unused_imports)]
+
     use av_metrics::video::ciede::{calculate_video_ciede, calculate_video_ciede_nosimd};
     use av_metrics::video::psnr::{calculate_video_apsnr, calculate_video_psnr};
     use av_metrics::video::psnr_hvs::calculate_video_psnr_hvs;

--- a/av_metrics_tests/src/lib.rs
+++ b/av_metrics_tests/src/lib.rs
@@ -8,11 +8,13 @@ mod tests {
     use av_metrics_decoders::FfmpegDecoder;
     #[cfg(not(feature = "ffmpeg"))]
     use av_metrics_decoders::Y4MDecoder;
+    use std::fs::File;
+    use std::io::BufReader;
     use std::path::Path;
 
     #[cfg(not(feature = "ffmpeg"))]
-    fn get_decoder<P: AsRef<Path>>(input: P) -> Result<Y4MDecoder, String> {
-        Y4MDecoder::new(input)
+    fn get_decoder<P: AsRef<Path>>(input: P) -> Result<Y4MDecoder<BufReader<File>>, String> {
+        av_metrics_decoders::y4m::new_decoder_from_file(input)
     }
 
     #[cfg(feature = "ffmpeg")]

--- a/av_metrics_tool/Cargo.toml
+++ b/av_metrics_tool/Cargo.toml
@@ -10,7 +10,7 @@ include = ["src/**/*", "LICENSE"]
 
 [dependencies]
 av-metrics = { version = "0.9", features = ["serde"] }
-av-metrics-decoders = "0.2.1"
+av-metrics-decoders = "0.3.1"
 clap = "4"
 console = "0.15.0"
 indicatif = "0.17.1"

--- a/av_metrics_tool/src/main.rs
+++ b/av_metrics_tool/src/main.rs
@@ -12,7 +12,9 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use std::error::Error;
 use std::fs::File;
-use std::io::{BufReader, BufWriter, Stdout, Write};
+#[cfg(not(feature = "ffmpeg"))]
+use std::io::BufReader;
+use std::io::{BufWriter, Stdout, Write};
 use std::path::Path;
 
 fn main() -> Result<(), String> {

--- a/av_metrics_tool/src/main.rs
+++ b/av_metrics_tool/src/main.rs
@@ -12,7 +12,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use std::error::Error;
 use std::fs::File;
-use std::io::{BufWriter, Stdout, Write};
+use std::io::{BufReader, BufWriter, Stdout, Write};
 use std::path::Path;
 
 fn main() -> Result<(), String> {
@@ -166,8 +166,8 @@ impl InputType {
 }
 
 #[cfg(not(feature = "ffmpeg"))]
-pub fn get_decoder<P: AsRef<Path>>(input: P) -> Result<Y4MDecoder, String> {
-    Y4MDecoder::new(input)
+pub fn get_decoder<P: AsRef<Path>>(input: P) -> Result<Y4MDecoder<BufReader<File>>, String> {
+    av_metrics_decoders::y4m::new_decoder_from_file(input)
 }
 
 #[cfg(feature = "ffmpeg")]


### PR DESCRIPTION
These are breaking changes[^1] because the `Y4MDecoder` type is exposed in the API (and got changed in `av-metrics-decoders`). The changes are pretty simple otherwise. I wanted to update some dependencies, but this should be done first I think

[^1]: Nevermind. The tests project is obviously not published/versioned and I'm not sure what compatibility guarantees the `av-metrics-tool` is supposed to make.