### PR TITLE
Fix clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,9 +635,9 @@ checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]

--- a/av_metrics/src/lib.rs
+++ b/av_metrics/src/lib.rs
@@ -19,6 +19,7 @@ pub mod video;
 ///
 /// This enum may be added to in the future and should not be assumed to be exhaustive.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum MetricsError {
     /// Indicates an input file could not be read for some reason.
     #[error("Could not read input file: {reason}")]
@@ -56,8 +57,4 @@ pub enum MetricsError {
         #[doc(hidden)]
         reason: String,
     },
-    /// Placeholder
-    #[doc(hidden)]
-    #[error("Unreachable")]
-    NonExhaustive,
 }

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -97,7 +97,6 @@ impl VideoMetric for Psnr {
 
         frame1.can_compare(frame2)?;
 
-        let bit_depth = bit_depth;
         let mut y = Default::default();
         let mut u = Default::default();
         let mut v = Default::default();

--- a/av_metrics/src/video/psnr_hvs.rs
+++ b/av_metrics/src/video/psnr_hvs.rs
@@ -85,7 +85,6 @@ impl VideoMetric for PsnrHvs {
 
         frame1.can_compare(frame2)?;
 
-        let bit_depth = bit_depth;
         let mut y = 0.0;
         let mut u = 0.0;
         let mut v = 0.0;

--- a/av_metrics/src/video/ssim.rs
+++ b/av_metrics/src/video/ssim.rs
@@ -246,7 +246,6 @@ impl VideoMetric for MsSsim {
 
         frame1.can_compare(frame2)?;
 
-        let bit_depth = bit_depth;
         let mut y = 0.0;
         let mut u = 0.0;
         let mut v = 0.0;


### PR DESCRIPTION
Now, this is *technically* a breaking change because `MetricsError::NonExhaustive` is *technically* part of the public API. But given that it is `doc(hidden)` and explicitly not supposed to be used, I think this change is fine? 

I also updated one crate, which should hopefully be uncontroversial (proc-macro2)