### PR TITLE
Fix FFmpeg build

### DIFF
--- a/av_metrics_decoders/Cargo.toml
+++ b/av_metrics_decoders/Cargo.toml
@@ -16,6 +16,7 @@ av-metrics = "0.9"
 ffmpeg-the-third = { version = "1.2.2", optional = true, default-features = false, features = [
     "codec",
     "format",
+    "non-exhaustive-enums"
 ] }
 vapoursynth = { version = "0.4.0", features = [
     "vsscript-functions",


### PR DESCRIPTION
Fixes the error that showed up in #299.

`non-exhaustive-enums` is a feature that basically allows compiling the ffmpeg crate even when the installed FFmpeg libraries are newer than the crate supports. 

This comes at the cost of implicitly ignoring new enum variants in the FFmpeg API, which is probably fine.

The alternative solution to this would be updating the [ffmpeg](https://github.com/shssoichiro/ffmpeg-the-third) crate to support the newest version (and keep it updated). Or change the CI so it only installs a fixed FFmpeg version.