### PR TITLE
Update shlex to fix security issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"


### PR DESCRIPTION
https://github.com/rust-av/av-metrics/security/dependabot/9

Not sure if bindgen/ffmpeg-the-third is actually affected by this. The upgrade should still be done out of an abundance of caution