### PR TITLE
Update ffmpeg-the-third to version 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,22 +130,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.64.0"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
- "peeking_take_while",
- "proc-macro2",
+  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash",
  "shlex",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -153,6 +153,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bumpalo"
@@ -388,25 +394,24 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "1.1.1+ffmpeg-6.0"
+version = "2.0.0+ffmpeg-7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a4b2e9c02074c0ee85661b23b3ac849bad6afc554b503c183975f5e2e0d3de"
+checksum = "a82bfdb0a7925996707f0a7dc37b2f3251ff5a15d26e78c586adb60c240dedc5"
 dependencies = [
  "bindgen",
  "cc",
  "libc",
- "num_cpus",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
 name = "ffmpeg-the-third"
-version = "1.2.2+ffmpeg-6.0"
+version = "2.0.1+ffmpeg-7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301c55f432cce71d0cc5266e8e70e69cc7a865f8aa8785c44cb56c3935a13715"
+checksum = "c4aa99eb55979d5c1db3b0b7a807a5e50dda07f5f6c2dbc6e9b50c205f611646"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "ffmpeg-sys-the-third",
  "libc",
 ]
@@ -903,7 +908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7df702c65dec1cfa3b93f824a1e58d5b0fdb82ac8a722596f43d7214282f56"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "thiserror",
  "vapoursynth-sys",

--- a/av_metrics_decoders/Cargo.toml
+++ b/av_metrics_decoders/Cargo.toml
@@ -8,12 +8,10 @@ license = "MIT"
 repository = "https://github.com/rust-av/av-metrics"
 include = ["src/**/*", "LICENSE"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1.0.66"
 av-metrics = "0.9"
-ffmpeg-the-third = { version = "1.2.2", optional = true, default-features = false, features = [
+ffmpeg-the-third = { version = "2.0", optional = true, default-features = false, features = [
     "codec",
     "format",
 ] }

--- a/av_metrics_decoders/src/ffmpeg.rs
+++ b/av_metrics_decoders/src/ffmpeg.rs
@@ -157,7 +157,12 @@ impl Decoder for FfmpegDecoder {
         loop {
             // This iterator is actually really stupid... it doesn't reset itself after each `new`.
             // But that solves our lifetime hell issues, ironically.
-            let packet = self.input_ctx.packets().next().map(|(_, packet)| packet);
+            let packet = self
+                .input_ctx
+                .packets()
+                .filter_map(Result::ok)
+                .next()
+                .map(|(_, packet)| packet);
 
             let mut packet = if let Some(packet) = packet {
                 packet


### PR DESCRIPTION
There's a slight change in the `ffmpeg-the-third` API, but it's mostly the same. Should be fine to bump `av-metrics-decoders` to 0.3.2 and not necessarily 0.4.0.

Prerequisite for #298.