### PR TITLE
Dependency maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,12 +540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,23 +547,6 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -713,28 +690,6 @@ name = "regex-syntax"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
-
-[[package]]
-name = "rust_hawktracer"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3480a29b927f66c6e06527be7f49ef4d291a01d694ec1fe85b0de71d6b02ac1"
-dependencies = [
- "rust_hawktracer_normal_macro",
- "rust_hawktracer_proc_macro",
-]
-
-[[package]]
-name = "rust_hawktracer_normal_macro"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a570059949e1dcdc6f35228fa389f54c2c84dfe0c94c05022baacd56eacd2e9"
-
-[[package]]
-name = "rust_hawktracer_proc_macro"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb626abdbed5e93f031baae60d72032f56bc964e11ac2ff65f2ba3ed98d6d3e1"
 
 [[package]]
 name = "rustc-hash"
@@ -884,17 +839,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "v_frame"
-version = "0.3.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148c23ce3c8dae5562911cba1c264eaa5e31e133e0d5d08455409de9dd540358"
-dependencies = [
- "cfg-if",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "rust_hawktracer",
-]
+checksum = "06b99be99e91ea12170d453a6547324ef2df3fcd79aaf336f5b1fff88ac89d84"
 
 [[package]]
 name = "vapoursynth"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,6 @@ dependencies = [
  "crossbeam",
  "itertools 0.14.0",
  "lab",
- "num-traits",
  "rayon",
  "serde",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "autocfg"
@@ -391,9 +391,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "ffmpeg-sys-the-third"
-version = "4.1.0+ffmpeg-8.0"
+version = "5.0.0+ffmpeg-8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c1bf5e362dfb2fbdf9b3e634f3d7f7f0f057103689f518ba4fd96813faf1ef"
+checksum = "b00c204bb97c2b6c0329104c3e8bcf58d4d13cc88a04233326570672e0c2c5c9"
 dependencies = [
  "bindgen",
  "cc",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "ffmpeg-the-third"
-version = "4.1.0+ffmpeg-8.0"
+version = "5.0.0+ffmpeg-8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a274244c87178cd01144536061d63114cecea74cb1037a3614c81cc7ca01e0"
+checksum = "791f0d9315e4f0a0861fa5c8ca8d70a1bd099cce72bff111b4f7ed8d6ebe8ba3"
 dependencies = [
  "bitflags",
  "ffmpeg-sys-the-third",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,15 +264,14 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
-version = "0.15.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
- "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -385,9 +384,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encode_unicode"
-version = "0.3.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "ffmpeg-sys-the-third"
@@ -437,14 +436,15 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.3"
+version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -485,12 +485,6 @@ name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -568,12 +562,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "proc-macro2"
@@ -826,9 +814,15 @@ checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.10"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"
@@ -940,6 +934,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,19 +975,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -995,25 +990,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1023,21 +1021,9 @@ checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1047,21 +1033,9 @@ checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1071,21 +1045,9 @@ checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ members = [
     "av_metrics_tests",
 ]
 
+[workspace.dependencies]
+av-metrics = { version = "0.9.1", path = "av_metrics" }
+av-metrics-decoders = { version = "0.3.2", path = "av_metrics_decoders" }
+
 [profile.dev]
 opt-level = 1
 
 [profile.release]
 lto = "thin"
 codegen-units = 1
-
-[patch.crates-io]
-av-metrics = { path = "av_metrics" }
-av-metrics-decoders = { path = "av_metrics_decoders" }

--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -12,7 +12,6 @@ include = ["src/**/*", "LICENSE"]
 crossbeam = "0.8"
 itertools = "0.14.0"
 lab = "0.11.0"
-num-traits = "0.2"
 rayon = "1.5"
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "2"

--- a/av_metrics/Cargo.toml
+++ b/av_metrics/Cargo.toml
@@ -16,7 +16,7 @@ num-traits = "0.2"
 rayon = "1.5"
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "2"
-v_frame = "0.3.1"
+v_frame = { version = "0.7", features = ["padding_api"] }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/av_metrics/benches/bench.rs
+++ b/av_metrics/benches/bench.rs
@@ -8,7 +8,7 @@ use av_metrics::video::psnr::calculate_frame_psnr;
 use av_metrics::video::psnr_hvs::calculate_frame_psnr_hvs;
 use av_metrics::video::ssim::{calculate_frame_msssim, calculate_frame_ssim};
 use av_metrics::video::Frame;
-use av_metrics::video::{ChromaSamplePosition, ChromaSampling, Pixel};
+use av_metrics::video::{ChromaSamplePosition, ChromaSubsampling, Pixel};
 use criterion::Criterion;
 use std::fs::File;
 use y4m::Decoder as Y4MDec;
@@ -26,7 +26,7 @@ fn get_video_frame<T: Pixel>(filename: &str) -> Frame<T> {
     let frame = dec.read_frame().unwrap();
     let mut f: Frame<T> = Frame::new_with_padding(width, height, chroma_sampling, 0);
 
-    let (chroma_width, _) = chroma_sampling.get_chroma_dimensions(width, height);
+    let (chroma_width, _) = chroma_sampling.chroma_dimensions(width, height).expect("not monochrome and can subsample");
     f.planes[0].copy_from_raw_u8(frame.get_y_plane(), width * bytes, bytes);
     convert_chroma_data(
         &mut f.planes[1],
@@ -48,18 +48,18 @@ fn get_video_frame<T: Pixel>(filename: &str) -> Frame<T> {
     f
 }
 
-fn map_y4m_color_space(color_space: y4m::Colorspace) -> (ChromaSampling, ChromaSamplePosition) {
+fn map_y4m_color_space(color_space: y4m::Colorspace) -> (ChromaSubsampling, ChromaSamplePosition) {
     use av_metrics::video::ChromaSamplePosition::*;
-    use av_metrics::video::ChromaSampling::*;
+    use av_metrics::video::ChromaSubsampling::*;
     use y4m::Colorspace::*;
     match color_space {
-        Cmono | Cmono12 => (Cs400, Unknown),
-        C420jpeg => (Cs420, Bilateral),
-        C420paldv => (Cs420, Interpolated),
-        C420mpeg2 => (Cs420, Vertical),
-        C420 | C420p10 | C420p12 => (Cs420, Colocated),
-        C422 | C422p10 | C422p12 => (Cs422, Vertical),
-        C444 | C444p10 | C444p12 => (Cs444, Colocated),
+        Cmono | Cmono12 => (Monochrome, Unknown),
+        C420jpeg => (Yuv420, Bilateral),
+        C420paldv => (Yuv420, Interpolated),
+        C420mpeg2 => (Yuv420, Vertical),
+        C420 | C420p10 | C420p12 => (Yuv420, Colocated),
+        C422 | C422p10 | C422p12 => (Yuv422, Vertical),
+        C444 | C444p10 | C444p12 => (Yuv444, Colocated),
         _ => unimplemented!(),
     }
 }
@@ -75,7 +75,7 @@ pub fn psnr_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("PSNR yuv420p8", |b| {
         b.iter(|| {
-            calculate_frame_psnr(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_psnr(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -91,7 +91,7 @@ pub fn psnrhvs_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("PSNR-HVS yuv420p8", |b| {
         b.iter(|| {
-            calculate_frame_psnr_hvs(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_psnr_hvs(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -107,7 +107,7 @@ pub fn ssim_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("SSIM yuv420p8", |b| {
         b.iter(|| {
-            calculate_frame_ssim(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ssim(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -123,7 +123,7 @@ pub fn msssim_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("MSSSIM yuv420p8", |b| {
         b.iter(|| {
-            calculate_frame_msssim(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_msssim(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -139,7 +139,7 @@ pub fn ciede2000_nosimd_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("CIEDE2000 yuv420p8 nosimd", |b| {
         b.iter(|| {
-            calculate_frame_ciede_nosimd(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ciede_nosimd(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -155,7 +155,7 @@ pub fn ciede2000_simd_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("CIEDE2000 yuv420p8", |b| {
         b.iter(|| {
-            calculate_frame_ciede(&frame1, &frame2, 8, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ciede(&frame1, &frame2, 8, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -171,7 +171,7 @@ pub fn psnr_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("PSNR yuv420p10", |b| {
         b.iter(|| {
-            calculate_frame_psnr(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_psnr(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -187,7 +187,7 @@ pub fn psnrhvs_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("PSNR-HVS yuv420p10", |b| {
         b.iter(|| {
-            calculate_frame_psnr_hvs(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_psnr_hvs(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -203,7 +203,7 @@ pub fn ssim_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("SSIM yuv420p10", |b| {
         b.iter(|| {
-            calculate_frame_ssim(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ssim(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -219,7 +219,7 @@ pub fn msssim_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("MSSSIM yuv420p10", |b| {
         b.iter(|| {
-            calculate_frame_msssim(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_msssim(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -235,7 +235,7 @@ pub fn ciede2000_nosimd_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("CIEDE2000 yuv420p10 nosimd", |b| {
         b.iter(|| {
-            calculate_frame_ciede_nosimd(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ciede_nosimd(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }
@@ -251,7 +251,7 @@ pub fn ciede2000_simd_10bit_benchmark(c: &mut Criterion) {
     ));
     c.bench_function("CIEDE2000 yuv420p10", |b| {
         b.iter(|| {
-            calculate_frame_ciede(&frame1, &frame2, 10, ChromaSampling::Cs420).unwrap();
+            calculate_frame_ciede(&frame1, &frame2, 10, ChromaSubsampling::Yuv420).unwrap();
         })
     });
 }

--- a/av_metrics/benches/bench.rs
+++ b/av_metrics/benches/bench.rs
@@ -7,8 +7,8 @@ use av_metrics::video::decode::convert_chroma_data;
 use av_metrics::video::psnr::calculate_frame_psnr;
 use av_metrics::video::psnr_hvs::calculate_frame_psnr_hvs;
 use av_metrics::video::ssim::{calculate_frame_msssim, calculate_frame_ssim};
-use av_metrics::video::Frame;
 use av_metrics::video::{ChromaSamplePosition, ChromaSubsampling, Pixel};
+use av_metrics::video::{Frame, FrameBuilder};
 use criterion::Criterion;
 use std::fs::File;
 use y4m::Decoder as Y4MDec;
@@ -24,12 +24,18 @@ fn get_video_frame<T: Pixel>(filename: &str) -> Frame<T> {
     let height = dec.get_height();
     let bytes = dec.get_bytes_per_sample();
     let frame = dec.read_frame().unwrap();
-    let mut f: Frame<T> = Frame::new_with_padding(width, height, chroma_sampling, 0);
+    let mut f: Frame<T> = FrameBuilder::new(width, height, chroma_sampling, bit_depth as u8)
+        .build()
+        .expect("can build frame");
 
-    let (chroma_width, _) = chroma_sampling.chroma_dimensions(width, height).expect("not monochrome and can subsample");
-    f.planes[0].copy_from_raw_u8(frame.get_y_plane(), width * bytes, bytes);
+    let (chroma_width, _) = chroma_sampling
+        .chroma_dimensions(width, height)
+        .expect("not monochrome and can subsample");
+    f.y_plane
+        .copy_from_u8_slice_with_stride(frame.get_y_plane(), width * bytes)
+        .expect("can copy");
     convert_chroma_data(
-        &mut f.planes[1],
+        f.plane_mut(1).expect("has plane 1"),
         chroma_sample_pos,
         bit_depth,
         frame.get_u_plane(),
@@ -37,7 +43,7 @@ fn get_video_frame<T: Pixel>(filename: &str) -> Frame<T> {
         bytes,
     );
     convert_chroma_data(
-        &mut f.planes[2],
+        f.plane_mut(2).expect("has plane 2"),
         chroma_sample_pos,
         bit_depth,
         frame.get_v_plane(),

--- a/av_metrics/src/video/ciede/mod.rs
+++ b/av_metrics/src/video/ciede/mod.rs
@@ -115,9 +115,9 @@ impl VideoMetric for Ciede2000 {
         frame1.can_compare(frame2)?;
 
         let dec = chroma_sampling.get_decimation().unwrap_or((1, 1));
-        let y_width = frame1.planes[0].cfg.width;
-        let y_height = frame1.planes[0].cfg.height;
-        let c_width = frame1.planes[1].cfg.width;
+        let y_width = frame1.y_plane.width();
+        let y_height = frame1.y_plane.height();
+        let c_width = frame1.plane(1).expect("has U plane").width();
         let delta_e_row_fn = get_delta_e_row_fn(bit_depth, dec.0, self.use_simd);
         // let mut delta_e_vec: Vec<f32> = vec![0.0; y_width * y_height];
 
@@ -135,14 +135,14 @@ impl VideoMetric for Ciede2000 {
             unsafe {
                 delta_e_row_fn(
                     FrameRow {
-                        y: &frame1.planes[0].data[y_range.clone()],
-                        u: &frame1.planes[1].data[c_range.clone()],
-                        v: &frame1.planes[2].data[c_range.clone()],
+                        y: &frame1.plane(0).expect("frame 1 has plane 0").data()[y_range.clone()],
+                        u: &frame1.plane(1).expect("frame 1 has plane 1").data()[c_range.clone()],
+                        v: &frame1.plane(2).expect("frame 1 has plane 2").data()[c_range.clone()],
                     },
                     FrameRow {
-                        y: &frame2.planes[0].data[y_range],
-                        u: &frame2.planes[1].data[c_range.clone()],
-                        v: &frame2.planes[2].data[c_range],
+                        y: &frame2.plane(0).expect("frame 2 has plane 0").data()[y_range],
+                        u: &frame2.plane(1).expect("frame 2 has plane 1").data()[c_range.clone()],
+                        v: &frame2.plane(2).expect("frame 2 has plane 2").data()[c_range],
                     },
                     &mut delta_e_vec[..],
                 );

--- a/av_metrics/src/video/ciede/mod.rs
+++ b/av_metrics/src/video/ciede/mod.rs
@@ -6,7 +6,8 @@
 //! [Kyle Siefring's](https://github.com/KyleSiefring/dump_ciede2000).
 
 use crate::video::decode::Decoder;
-use crate::video::pixel::{CastFromPrimitive, Pixel};
+use crate::video::pixel::Pixel;
+use crate::video::ChromaSubsampling;
 use crate::video::VideoMetric;
 use crate::MetricsError;
 use std::f64;
@@ -61,7 +62,7 @@ pub fn calculate_frame_ciede<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<f64, Box<dyn Error>> {
     Ciede2000::default().process_frame(frame1, frame2, bit_depth, chroma_sampling)
 }
@@ -76,7 +77,7 @@ pub fn calculate_frame_ciede_nosimd<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<f64, Box<dyn Error>> {
     (Ciede2000 { use_simd: false }).process_frame(frame1, frame2, bit_depth, chroma_sampling)
 }
@@ -93,7 +94,6 @@ impl Default for Ciede2000 {
 
 use rayon::prelude::*;
 use v_frame::frame::Frame;
-use v_frame::prelude::ChromaSampling;
 
 impl VideoMetric for Ciede2000 {
     type FrameResult = f64;
@@ -104,7 +104,7 @@ impl VideoMetric for Ciede2000 {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        chroma_sampling: ChromaSampling,
+        chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {
         if (size_of::<T>() == 1 && bit_depth > 8) || (size_of::<T>() == 2 && bit_depth <= 8) {
             return Err(Box::new(MetricsError::InputMismatch {

--- a/av_metrics/src/video/ciede/mod.rs
+++ b/av_metrics/src/video/ciede/mod.rs
@@ -114,17 +114,17 @@ impl VideoMetric for Ciede2000 {
 
         frame1.can_compare(frame2)?;
 
-        let dec = chroma_sampling.get_decimation().unwrap_or((1, 1));
+        let (x_ratio, y_ratio) = chroma_sampling.subsample_ratio().expect("not monochrome");
         let y_width = frame1.y_plane.width();
         let y_height = frame1.y_plane.height();
         let c_width = frame1.plane(1).expect("has U plane").width();
-        let delta_e_row_fn = get_delta_e_row_fn(bit_depth, dec.0, self.use_simd);
+        let delta_e_row_fn = get_delta_e_row_fn(bit_depth, x_ratio.get(), self.use_simd);
         // let mut delta_e_vec: Vec<f32> = vec![0.0; y_width * y_height];
 
         let delta_e_per_line = (0..y_height).into_par_iter().map(|i| {
             let y_start = i * y_width;
             let y_end = y_start + y_width;
-            let c_start = (i >> dec.1) * c_width;
+            let c_start = (i / usize::from(y_ratio.get())) * c_width;
             let c_end = c_start + c_width;
 
             let y_range = y_start..y_end;
@@ -182,10 +182,10 @@ pub(crate) struct FrameRow<'a, T: Pixel> {
 
 type DeltaERowFn<T> = unsafe fn(FrameRow<T>, FrameRow<T>, &mut [f32]);
 
-fn get_delta_e_row_fn<T: Pixel>(bit_depth: usize, xdec: usize, _simd: bool) -> DeltaERowFn<T> {
+fn get_delta_e_row_fn<T: Pixel>(bit_depth: usize, x_ratio: u8, _simd: bool) -> DeltaERowFn<T> {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     {
-        if is_x86_feature_detected!("avx2") && xdec == 1 && _simd {
+        if is_x86_feature_detected!("avx2") && x_ratio == 2 && _simd {
             return match bit_depth {
                 8 => BD8::delta_e_row_avx2,
                 10 => BD10::delta_e_row_avx2,
@@ -194,13 +194,13 @@ fn get_delta_e_row_fn<T: Pixel>(bit_depth: usize, xdec: usize, _simd: bool) -> D
             };
         }
     }
-    match (bit_depth, xdec) {
-        (8, 1) => BD8::delta_e_row_scalar,
-        (10, 1) => BD10::delta_e_row_scalar,
-        (12, 1) => BD12::delta_e_row_scalar,
-        (8, 0) => BD8_444::delta_e_row_scalar,
-        (10, 0) => BD10_444::delta_e_row_scalar,
-        (12, 0) => BD12_444::delta_e_row_scalar,
+    match (bit_depth, x_ratio) {
+        (8, 2) => BD8::delta_e_row_scalar,
+        (10, 2) => BD10::delta_e_row_scalar,
+        (12, 2) => BD12::delta_e_row_scalar,
+        (8, 1) => BD8_444::delta_e_row_scalar,
+        (10, 1) => BD10_444::delta_e_row_scalar,
+        (12, 1) => BD12_444::delta_e_row_scalar,
         _ => unreachable!(),
     }
 }
@@ -292,16 +292,8 @@ pub(crate) trait DeltaEScalar: Colorspace {
                 res_row
             ) {
                 *res = Self::delta_e_scalar(
-                    (
-                        u16::cast_from(*y1),
-                        u16::cast_from(*u1),
-                        u16::cast_from(*v1),
-                    ),
-                    (
-                        u16::cast_from(*y2),
-                        u16::cast_from(*u2),
-                        u16::cast_from(*v2),
-                    ),
+                    ((*y1).into(), (*u1).into(), (*v1).into()),
+                    ((*y2).into(), (*u2).into(), (*v2).into()),
                 );
             }
         } else {
@@ -309,16 +301,8 @@ pub(crate) trait DeltaEScalar: Colorspace {
                 izip!(row1.y, row1.u, row1.v, row2.y, row2.u, row2.v, res_row)
             {
                 *res = Self::delta_e_scalar(
-                    (
-                        u16::cast_from(*y1),
-                        u16::cast_from(*u1),
-                        u16::cast_from(*v1),
-                    ),
-                    (
-                        u16::cast_from(*y2),
-                        u16::cast_from(*u2),
-                        u16::cast_from(*v2),
-                    ),
+                    ((*y1).into(), (*u1).into(), (*v1).into()),
+                    ((*y2).into(), (*u2).into(), (*v2).into()),
                 );
             }
         }
@@ -429,19 +413,19 @@ mod avx2 {
                                 load_luma(
                                     &chunk1_y
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
                                     &chunk1_u
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
                                     &chunk1_v
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                             ),
@@ -449,19 +433,19 @@ mod avx2 {
                                 load_luma(
                                     &chunk2_y
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
                                     &chunk2_u
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
                                     &chunk2_v
                                         .iter()
-                                        .map(|p| u8::cast_from(*p))
+                                        .map(|&p| p.try_into().expect("Pixel is u8"))
                                         .collect::<Vec<_>>(),
                                 ),
                             ),
@@ -508,43 +492,21 @@ mod avx2 {
 
                         Self::delta_e_avx2(
                             (
-                                load_luma(
-                                    &chunk1_y
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
+                                load_luma(&chunk1_y.iter().map(|&p| p.into()).collect::<Vec<_>>()),
+                                load_chroma(
+                                    &chunk1_u.iter().map(|&p| p.into()).collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
-                                    &chunk1_u
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
-                                ),
-                                load_chroma(
-                                    &chunk1_v
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
+                                    &chunk1_v.iter().map(|&p| p.into()).collect::<Vec<_>>(),
                                 ),
                             ),
                             (
-                                load_luma(
-                                    &chunk2_y
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
+                                load_luma(&chunk2_y.iter().map(|&p| p.into()).collect::<Vec<_>>()),
+                                load_chroma(
+                                    &chunk2_u.iter().map(|&p| p.into()).collect::<Vec<_>>(),
                                 ),
                                 load_chroma(
-                                    &chunk2_u
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
-                                ),
-                                load_chroma(
-                                    &chunk2_v
-                                        .iter()
-                                        .map(|p| u16::cast_from(*p))
-                                        .collect::<Vec<_>>(),
+                                    &chunk2_v.iter().map(|&p| p.into()).collect::<Vec<_>>(),
                                 ),
                             ),
                             res_chunk,

--- a/av_metrics/src/video/decode.rs
+++ b/av_metrics/src/video/decode.rs
@@ -111,7 +111,9 @@ pub fn convert_chroma_data<T: Pixel>(
 ) {
     if chroma_pos != ChromaSamplePosition::Vertical {
         // TODO: Also convert Interpolated chromas
-        plane_data.copy_from_raw_u8(source, source_stride, source_bytewidth);
+        plane_data
+            .copy_from_u8_slice_with_stride(source, source_stride)
+            .expect("can copy");
         return;
     }
 
@@ -128,9 +130,9 @@ pub fn convert_chroma_data<T: Pixel>(
         convert_u16
     };
 
-    let output_data = &mut plane_data.data;
-    let width = plane_data.cfg.width;
-    let height = plane_data.cfg.height;
+    let width = plane_data.width();
+    let height = plane_data.height();
+    let output_data = plane_data.data_mut();
     for y in 0..height {
         // Filter: [4 -17 114 35 -9 1]/128, derived from a 6-tap Lanczos window.
         let in_row = &source[(y * source_stride)..];

--- a/av_metrics/src/video/decode.rs
+++ b/av_metrics/src/video/decode.rs
@@ -119,13 +119,13 @@ pub fn convert_chroma_data<T: Pixel>(
 
     let get_pixel = if source_bytewidth == 1 {
         fn convert_u8(line: &[u8], index: usize) -> i32 {
-            i32::cast_from(line[index])
+            i32::from(line[index])
         }
         convert_u8
     } else {
         fn convert_u16(line: &[u8], index: usize) -> i32 {
             let index = index * 2;
-            i32::cast_from(u16::cast_from(line[index + 1]) << 8 | u16::cast_from(line[index]))
+            i32::from(u16::from_ne_bytes([line[index + 1], line[index]]))
         }
         convert_u16
     };
@@ -139,55 +139,50 @@ pub fn convert_chroma_data<T: Pixel>(
         let out_row = &mut output_data[(y * width)..];
         let breakpoint = cmp::min(width, 2);
         for x in 0..breakpoint {
-            out_row[x] = T::cast_from(clamp(
-                (4 * get_pixel(in_row, 0) - 17 * get_pixel(in_row, x.saturating_sub(1))
-                    + 114 * get_pixel(in_row, x)
-                    + 35 * get_pixel(in_row, cmp::min(x + 1, width - 1))
-                    - 9 * get_pixel(in_row, cmp::min(x + 2, width - 1))
-                    + get_pixel(in_row, cmp::min(x + 3, width - 1))
-                    + 64)
-                    >> 7,
-                0,
-                (1 << bit_depth) - 1,
-            ));
+            let val = (4 * get_pixel(in_row, 0) - 17 * get_pixel(in_row, x.saturating_sub(1))
+                + 114 * get_pixel(in_row, x)
+                + 35 * get_pixel(in_row, cmp::min(x + 1, width - 1))
+                - 9 * get_pixel(in_row, cmp::min(x + 2, width - 1))
+                + get_pixel(in_row, cmp::min(x + 3, width - 1))
+                + 64)
+                >> 7;
+
+            let clamped = val
+                .clamp(0, (1 << bit_depth) - 1)
+                .try_into()
+                .expect("fits into u16");
+            out_row[x] = T::try_from(clamped).expect("clamped value fits into T");
         }
         let breakpoint2 = width - 3;
         for x in breakpoint..breakpoint2 {
-            out_row[x] = T::cast_from(clamp(
-                (4 * get_pixel(in_row, x - 2) - 17 * get_pixel(in_row, x - 1)
-                    + 114 * get_pixel(in_row, x)
-                    + 35 * get_pixel(in_row, x + 1)
-                    - 9 * get_pixel(in_row, x + 2)
-                    + get_pixel(in_row, x + 3)
-                    + 64)
-                    >> 7,
-                0,
-                (1 << bit_depth) - 1,
-            ));
+            let val = (4 * get_pixel(in_row, x - 2) - 17 * get_pixel(in_row, x - 1)
+                + 114 * get_pixel(in_row, x)
+                + 35 * get_pixel(in_row, x + 1)
+                - 9 * get_pixel(in_row, x + 2)
+                + get_pixel(in_row, x + 3)
+                + 64)
+                >> 7;
+
+            let clamped = val
+                .clamp(0, (1 << bit_depth) - 1)
+                .try_into()
+                .expect("fits into u16");
+            out_row[x] = T::try_from(clamped).expect("clamped value fits into T");
         }
         for x in breakpoint2..width {
-            out_row[x] = T::cast_from(clamp(
-                (4 * get_pixel(in_row, x - 2) - 17 * get_pixel(in_row, x - 1)
-                    + 114 * get_pixel(in_row, x)
-                    + 35 * get_pixel(in_row, cmp::min(x + 1, width - 1))
-                    - 9 * get_pixel(in_row, cmp::min(x + 2, width - 1))
-                    + get_pixel(in_row, width - 1)
-                    + 64)
-                    >> 7,
-                0,
-                (1 << bit_depth) - 1,
-            ));
-        }
-    }
-}
+            let val = (4 * get_pixel(in_row, x - 2) - 17 * get_pixel(in_row, x - 1)
+                + 114 * get_pixel(in_row, x)
+                + 35 * get_pixel(in_row, cmp::min(x + 1, width - 1))
+                - 9 * get_pixel(in_row, cmp::min(x + 2, width - 1))
+                + get_pixel(in_row, width - 1)
+                + 64)
+                >> 7;
 
-#[inline]
-fn clamp<T: PartialOrd>(input: T, min: T, max: T) -> T {
-    if input < min {
-        min
-    } else if input > max {
-        max
-    } else {
-        input
+            let clamped = val
+                .clamp(0, (1 << bit_depth) - 1)
+                .try_into()
+                .expect("fits into u16");
+            out_row[x] = T::try_from(clamped).expect("clamped value fits into T");
+        }
     }
 }

--- a/av_metrics/src/video/decode.rs
+++ b/av_metrics/src/video/decode.rs
@@ -2,10 +2,9 @@
 //! Prebuilt decoders are included in the `av-metrics-decoders` crate.
 
 use crate::video::pixel::Pixel;
-use crate::video::{ChromaSamplePosition, ChromaSampling};
+use crate::video::{ChromaSamplePosition, ChromaSubsampling};
 use std::cmp;
 use v_frame::frame::Frame;
-use v_frame::pixel::CastFromPrimitive;
 use v_frame::plane::Plane;
 
 /// A trait for allowing metrics to decode generic video formats.
@@ -48,7 +47,7 @@ pub struct VideoDetails {
     /// Bit-depth of the Video
     pub bit_depth: usize,
     /// ChromaSampling of the Video.
-    pub chroma_sampling: ChromaSampling,
+    pub chroma_sampling: ChromaSubsampling,
     /// Chroma Sampling Position of the Video.
     pub chroma_sample_position: ChromaSamplePosition,
     /// Add Time base of the Video.
@@ -63,7 +62,7 @@ impl Default for VideoDetails {
             width: 640,
             height: 480,
             bit_depth: 8,
-            chroma_sampling: ChromaSampling::Cs420,
+            chroma_sampling: ChromaSubsampling::Yuv420,
             chroma_sample_position: ChromaSamplePosition::Unknown,
             time_base: Rational { num: 30, den: 1 },
             luma_padding: 0,

--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -12,8 +12,9 @@ use decode::*;
 use std::error::Error;
 
 pub use pixel::*;
-pub use v_frame::frame::Frame;
-pub use v_frame::plane::Plane;
+pub use v_frame::chroma::ChromaSubsampling;
+pub use v_frame::frame::{Frame, FrameBuilder, FrameError};
+pub use v_frame::plane::{CopyError, Plane, PlaneGeometry, SubsamplingError};
 
 trait FrameCompare {
     fn can_compare(&self, other: &Self) -> Result<(), MetricsError>;
@@ -44,20 +45,18 @@ impl<T: Pixel> PlaneCompare for Plane<T> {
     }
 }
 
-pub use v_frame::pixel::ChromaSampling;
-
 pub(crate) trait ChromaWeight {
     fn get_chroma_weight(self) -> f64;
 }
 
-impl ChromaWeight for ChromaSampling {
+impl ChromaWeight for ChromaSubsampling {
     /// The relative impact of chroma planes compared to luma
     fn get_chroma_weight(self) -> f64 {
         match self {
-            ChromaSampling::Cs420 => 0.25,
-            ChromaSampling::Cs422 => 0.5,
-            ChromaSampling::Cs444 => 1.0,
-            ChromaSampling::Cs400 => 0.0,
+            ChromaSubsampling::Yuv420 => 0.25,
+            ChromaSubsampling::Yuv422 => 0.5,
+            ChromaSubsampling::Yuv444 => 1.0,
+            ChromaSubsampling::Monochrome => 0.0,
         }
     }
 }
@@ -137,7 +136,7 @@ trait VideoMetric: Send + Sync {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        chroma_sampling: ChromaSampling,
+        chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>>;
 
     fn aggregate_frame_results(

--- a/av_metrics/src/video/mod.rs
+++ b/av_metrics/src/video/mod.rs
@@ -22,9 +22,9 @@ trait FrameCompare {
 
 impl<T: Pixel> FrameCompare for Frame<T> {
     fn can_compare(&self, other: &Self) -> Result<(), MetricsError> {
-        self.planes[0].can_compare(&other.planes[0])?;
-        self.planes[1].can_compare(&other.planes[1])?;
-        self.planes[2].can_compare(&other.planes[2])?;
+        self.plane(0).can_compare(&other.plane(0))?;
+        self.plane(1).can_compare(&other.plane(1))?;
+        self.plane(2).can_compare(&other.plane(2))?;
 
         Ok(())
     }
@@ -34,14 +34,14 @@ pub(crate) trait PlaneCompare {
     fn can_compare(&self, other: &Self) -> Result<(), MetricsError>;
 }
 
-impl<T: Pixel> PlaneCompare for Plane<T> {
+impl<T: Pixel> PlaneCompare for Option<&Plane<T>> {
     fn can_compare(&self, other: &Self) -> Result<(), MetricsError> {
-        if self.cfg != other.cfg {
-            return Err(MetricsError::InputMismatch {
+        match (self, other) {
+            (Some(s), Some(o)) if s.geometry() == o.geometry() => Ok(()),
+            _ => Err(MetricsError::InputMismatch {
                 reason: "Video resolution does not match",
-            });
+            }),
         }
-        Ok(())
     }
 }
 

--- a/av_metrics/src/video/pixel.rs
+++ b/av_metrics/src/video/pixel.rs
@@ -2,4 +2,4 @@
 //!
 //! Borrowed from rav1e.
 
-pub use v_frame::pixel::{CastFromPrimitive, Pixel};
+pub use v_frame::pixel::Pixel;

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -198,10 +198,10 @@ fn calculate_psnr(metrics: PsnrMetrics) -> f64 {
 /// to the compressed version.
 fn calculate_plane_total_squared_error<T: Pixel>(plane1: &Plane<T>, plane2: &Plane<T>) -> f64 {
     plane1
-        .data
+        .data()
         .iter()
-        .zip(plane2.data.iter())
-        .map(|(a, b)| (i32::cast_from(*a) - i32::cast_from(*b)).unsigned_abs() as u64)
+        .zip(plane2.data().iter())
+        .map(|(&a, &b)| u64::from(a.into().abs_diff(b.into())))
         .map(|err| err * err)
         .sum::<u64>() as f64
 }

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -5,7 +5,6 @@
 //! See https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio for more details.
 
 use crate::video::decode::Decoder;
-use crate::video::pixel::CastFromPrimitive;
 use crate::video::pixel::Pixel;
 use crate::video::{PlanarMetrics, VideoMetric};
 use crate::MetricsError;
@@ -13,8 +12,8 @@ use std::error::Error;
 use std::mem::size_of;
 use v_frame::frame::Frame;
 use v_frame::plane::Plane;
-use v_frame::prelude::ChromaSampling;
 
+use super::ChromaSubsampling;
 use super::FrameCompare;
 
 /// Calculates the PSNR for two videos. Higher is better.
@@ -59,7 +58,7 @@ pub fn calculate_frame_psnr<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let metrics = Psnr.process_frame(frame1, frame2, bit_depth, chroma_sampling)?;
     Ok(PlanarMetrics {
@@ -87,7 +86,7 @@ impl VideoMetric for Psnr {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        _chroma_sampling: ChromaSampling,
+        _chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {
         if (size_of::<T>() == 1 && bit_depth > 8) || (size_of::<T>() == 2 && bit_depth <= 8) {
             return Err(Box::new(MetricsError::InputMismatch {

--- a/av_metrics/src/video/psnr.rs
+++ b/av_metrics/src/video/psnr.rs
@@ -102,13 +102,25 @@ impl VideoMetric for Psnr {
 
         rayon::scope(|s| {
             s.spawn(|_| {
-                y = calculate_plane_psnr_metrics(&frame1.planes[0], &frame2.planes[0], bit_depth)
+                y = calculate_plane_psnr_metrics(
+                    frame1.plane(0).expect("frame 1 has plane 0"),
+                    frame2.plane(0).expect("frame 2 has plane 0"),
+                    bit_depth,
+                )
             });
             s.spawn(|_| {
-                u = calculate_plane_psnr_metrics(&frame1.planes[1], &frame2.planes[1], bit_depth)
+                u = calculate_plane_psnr_metrics(
+                    frame1.plane(1).expect("frame 1 has plane 1"),
+                    frame2.plane(1).expect("frame 2 has plane 1"),
+                    bit_depth,
+                )
             });
             s.spawn(|_| {
-                v = calculate_plane_psnr_metrics(&frame1.planes[2], &frame2.planes[2], bit_depth)
+                v = calculate_plane_psnr_metrics(
+                    frame1.plane(2).expect("frame 1 has plane 2"),
+                    frame2.plane(2).expect("frame 2 has plane 2"),
+                    bit_depth,
+                )
             });
         });
 
@@ -169,7 +181,7 @@ fn calculate_plane_psnr_metrics<T: Pixel>(
     let max = (1 << bit_depth) - 1;
     PsnrMetrics {
         sq_err,
-        n_pixels: plane1.cfg.width * plane1.cfg.height,
+        n_pixels: plane1.width() * plane1.height(),
         sample_max: max,
     }
 }

--- a/av_metrics/src/video/psnr_hvs.rs
+++ b/av_metrics/src/video/psnr_hvs.rs
@@ -247,8 +247,8 @@ fn calculate_plane_psnr_hvs<T: Pixel>(
 
             for i in 0..8 {
                 for j in 0..8 {
-                    p1[i * 8 + j] = i16::cast_from(plane1.data()[(y + i) * stride + x + j]);
-                    p2[i * 8 + j] = i16::cast_from(plane2.data()[(y + i) * stride + x + j]);
+                    p1[i * 8 + j] = plane1.data()[(y + i) * stride + x + j].into().cast_signed();
+                    p2[i * 8 + j] = plane2.data()[(y + i) * stride + x + j].into().cast_signed();
 
                     let sub = ((i & 12) >> 2) + ((j & 12) >> 1);
                     p1_gmean += p1[i * 8 + j] as f64;

--- a/av_metrics/src/video/psnr_hvs.rs
+++ b/av_metrics/src/video/psnr_hvs.rs
@@ -90,13 +90,28 @@ impl VideoMetric for PsnrHvs {
 
         rayon::scope(|s| {
             s.spawn(|_| {
-                y = calculate_plane_psnr_hvs(&frame1.planes[0], &frame2.planes[0], 0, bit_depth)
+                y = calculate_plane_psnr_hvs(
+                    frame1.plane(0).expect("frame 1 has plane 0"),
+                    frame2.plane(0).expect("frame 2 has plane 0"),
+                    0,
+                    bit_depth,
+                )
             });
             s.spawn(|_| {
-                u = calculate_plane_psnr_hvs(&frame1.planes[1], &frame2.planes[1], 1, bit_depth)
+                u = calculate_plane_psnr_hvs(
+                    frame1.plane(1).expect("frame 1 has plane 1"),
+                    frame2.plane(1).expect("frame 2 has plane 1"),
+                    1,
+                    bit_depth,
+                )
             });
             s.spawn(|_| {
-                v = calculate_plane_psnr_hvs(&frame1.planes[2], &frame2.planes[2], 2, bit_depth)
+                v = calculate_plane_psnr_hvs(
+                    frame1.plane(2).expect("frame 1 has plane 2"),
+                    frame2.plane(2).expect("frame 2 has plane 2"),
+                    2,
+                    bit_depth,
+                )
             });
         });
 
@@ -208,15 +223,15 @@ fn calculate_plane_psnr_hvs<T: Pixel>(
         }
     }
 
-    let height = plane1.cfg.height;
-    let width = plane1.cfg.width;
-    let stride = plane1.cfg.stride;
+    let height = plane1.height();
+    let width = plane1.width();
+    let stride = plane1.geometry().stride();
     let mut p1 = [0i16; 8 * 8];
     let mut p2 = [0i16; 8 * 8];
     let mut dct_p1 = [0i32; 8 * 8];
     let mut dct_p2 = [0i32; 8 * 8];
-    assert!(plane1.data.len() >= stride * height);
-    assert!(plane2.data.len() >= stride * height);
+    assert!(plane1.data().len() >= stride * height);
+    assert!(plane2.data().len() >= stride * height);
     for y in (0..(height - STEP)).step_by(STEP) {
         for x in (0..(width - STEP)).step_by(STEP) {
             let mut p1_means = [0.0; 4];
@@ -232,8 +247,8 @@ fn calculate_plane_psnr_hvs<T: Pixel>(
 
             for i in 0..8 {
                 for j in 0..8 {
-                    p1[i * 8 + j] = i16::cast_from(plane1.data[(y + i) * stride + x + j]);
-                    p2[i * 8 + j] = i16::cast_from(plane2.data[(y + i) * stride + x + j]);
+                    p1[i * 8 + j] = i16::cast_from(plane1.data()[(y + i) * stride + x + j]);
+                    p2[i * 8 + j] = i16::cast_from(plane2.data()[(y + i) * stride + x + j]);
 
                     let sub = ((i & 12) >> 2) + ((j & 12) >> 1);
                     p1_gmean += p1[i * 8 + j] as f64;

--- a/av_metrics/src/video/psnr_hvs.rs
+++ b/av_metrics/src/video/psnr_hvs.rs
@@ -7,7 +7,6 @@
 //! See https://en.wikipedia.org/wiki/Peak_signal-to-noise_ratio for more details.
 
 use crate::video::decode::Decoder;
-use crate::video::pixel::CastFromPrimitive;
 use crate::video::pixel::Pixel;
 use crate::video::ChromaWeight;
 use crate::video::{PlanarMetrics, VideoMetric};
@@ -16,8 +15,8 @@ use std::error::Error;
 use std::mem::size_of;
 use v_frame::frame::Frame;
 use v_frame::plane::Plane;
-use v_frame::prelude::ChromaSampling;
 
+use super::ChromaSubsampling;
 use super::FrameCompare;
 
 /// Calculates the PSNR-HVS score between two videos. Higher is better.
@@ -43,7 +42,7 @@ pub fn calculate_frame_psnr_hvs<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let processor = PsnrHvs::default();
     let result = processor.process_frame(frame1, frame2, bit_depth, chroma_sampling)?;
@@ -75,7 +74,7 @@ impl VideoMetric for PsnrHvs {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        _chroma_sampling: ChromaSampling,
+        _chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {
         if (size_of::<T>() == 1 && bit_depth > 8) || (size_of::<T>() == 2 && bit_depth <= 8) {
             return Err(Box::new(MetricsError::InputMismatch {

--- a/av_metrics/src/video/ssim.rs
+++ b/av_metrics/src/video/ssim.rs
@@ -9,7 +9,6 @@
 //! See https://en.wikipedia.org/wiki/Structural_similarity for more details.
 
 use crate::video::decode::Decoder;
-use crate::video::pixel::CastFromPrimitive;
 use crate::video::pixel::Pixel;
 use crate::video::ChromaWeight;
 use crate::video::{PlanarMetrics, VideoMetric};
@@ -20,8 +19,8 @@ use std::f64::consts::{E, PI};
 use std::mem::size_of;
 use v_frame::frame::Frame;
 use v_frame::plane::Plane;
-use v_frame::prelude::ChromaSampling;
 
+use super::ChromaSubsampling;
 use super::FrameCompare;
 
 /// Calculates the SSIM score between two videos. Higher is better.
@@ -47,7 +46,7 @@ pub fn calculate_frame_ssim<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let processor = Ssim::default();
     let result = processor.process_frame(frame1, frame2, bit_depth, chroma_sampling)?;
@@ -79,7 +78,7 @@ impl VideoMetric for Ssim {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        _chroma_sampling: ChromaSampling,
+        _chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {
         if (size_of::<T>() == 1 && bit_depth > 8) || (size_of::<T>() == 2 && bit_depth <= 8) {
             return Err(Box::new(MetricsError::InputMismatch {
@@ -204,7 +203,7 @@ pub fn calculate_frame_msssim<T: Pixel>(
     frame1: &Frame<T>,
     frame2: &Frame<T>,
     bit_depth: usize,
-    chroma_sampling: ChromaSampling,
+    chroma_sampling: ChromaSubsampling,
 ) -> Result<PlanarMetrics, Box<dyn Error>> {
     let processor = MsSsim::default();
     let result = processor.process_frame(frame1, frame2, bit_depth, chroma_sampling)?;
@@ -236,7 +235,7 @@ impl VideoMetric for MsSsim {
         frame1: &Frame<T>,
         frame2: &Frame<T>,
         bit_depth: usize,
-        _chroma_sampling: ChromaSampling,
+        _chroma_sampling: ChromaSubsampling,
     ) -> Result<Self::FrameResult, Box<dyn Error>> {
         if (size_of::<T>() == 1 && bit_depth > 8) || (size_of::<T>() == 2 && bit_depth <= 8) {
             return Err(Box::new(MetricsError::InputMismatch {

--- a/av_metrics/src/video/ssim.rs
+++ b/av_metrics/src/video/ssim.rs
@@ -98,14 +98,15 @@ impl VideoMetric for Ssim {
 
         rayon::scope(|s| {
             s.spawn(|_| {
+                let y_plane = &frame1.y_plane;
                 let y_kernel = build_gaussian_kernel(
-                    frame1.planes[0].cfg.height as f64 * 1.5 / 256.0,
-                    cmp::min(frame1.planes[0].cfg.width, frame1.planes[0].cfg.height),
+                    y_plane.height() as f64 * 1.5 / 256.0,
+                    y_plane.width().min(y_plane.height()),
                     KERNEL_WEIGHT,
                 );
                 y = calculate_plane_ssim(
-                    &frame1.planes[0],
-                    &frame2.planes[0],
+                    &frame1.y_plane,
+                    &frame2.y_plane,
                     sample_max,
                     &y_kernel,
                     &y_kernel,
@@ -113,14 +114,15 @@ impl VideoMetric for Ssim {
             });
 
             s.spawn(|_| {
+                let u_plane = frame1.u_plane.as_ref().expect("frame 1 has U plane");
                 let u_kernel = build_gaussian_kernel(
-                    frame1.planes[1].cfg.height as f64 * 1.5 / 256.0,
-                    cmp::min(frame1.planes[1].cfg.width, frame1.planes[1].cfg.height),
+                    u_plane.height() as f64 * 1.5 / 256.0,
+                    u_plane.width().min(u_plane.height()),
                     KERNEL_WEIGHT,
                 );
                 u = calculate_plane_ssim(
-                    &frame1.planes[1],
-                    &frame2.planes[1],
+                    u_plane,
+                    frame2.u_plane.as_ref().expect("frame 2 has U plane"),
                     sample_max,
                     &u_kernel,
                     &u_kernel,
@@ -128,14 +130,15 @@ impl VideoMetric for Ssim {
             });
 
             s.spawn(|_| {
+                let v_plane = frame1.v_plane.as_ref().expect("frame 1 has V plane");
                 let v_kernel = build_gaussian_kernel(
-                    frame1.planes[2].cfg.height as f64 * 1.5 / 256.0,
-                    cmp::min(frame1.planes[2].cfg.width, frame1.planes[2].cfg.height),
+                    v_plane.height() as f64 * 1.5 / 256.0,
+                    v_plane.width().min(v_plane.height()),
                     KERNEL_WEIGHT,
                 );
                 v = calculate_plane_ssim(
-                    &frame1.planes[2],
-                    &frame2.planes[2],
+                    v_plane,
+                    frame2.v_plane.as_ref().expect("frame 2 has V plane"),
                     sample_max,
                     &v_kernel,
                     &v_kernel,
@@ -250,14 +253,20 @@ impl VideoMetric for MsSsim {
         let mut v = 0.0;
 
         rayon::scope(|s| {
+            s.spawn(|_| y = calculate_plane_msssim(&frame1.y_plane, &frame2.y_plane, bit_depth));
             s.spawn(|_| {
-                y = calculate_plane_msssim(&frame1.planes[0], &frame2.planes[0], bit_depth)
+                u = calculate_plane_msssim(
+                    frame1.plane(1).expect("frame 1 has plane 1"),
+                    frame2.plane(1).expect("frame 2 has plane 1"),
+                    bit_depth,
+                )
             });
             s.spawn(|_| {
-                u = calculate_plane_msssim(&frame1.planes[1], &frame2.planes[1], bit_depth)
-            });
-            s.spawn(|_| {
-                v = calculate_plane_msssim(&frame1.planes[2], &frame2.planes[2], bit_depth)
+                v = calculate_plane_msssim(
+                    frame1.plane(2).expect("frame 1 has plane 2"),
+                    frame2.plane(2).expect("frame 2 has plane 2"),
+                    bit_depth,
+                )
             });
         });
 
@@ -315,8 +324,8 @@ fn calculate_plane_ssim<T: Pixel>(
     calculate_plane_ssim_internal(
         &vec1,
         &vec2,
-        plane1.cfg.width,
-        plane1.cfg.height,
+        plane1.width(),
+        plane1.height(),
         sample_max,
         vert_kernel,
         horiz_kernel,
@@ -411,8 +420,8 @@ fn calculate_plane_msssim<T: Pixel>(plane1: &Plane<T>, plane2: &Plane<T>, bit_de
     let mut sample_max = (1 << bit_depth) - 1;
     let mut ssim = [0.0; 5];
     let mut cs = [0.0; 5];
-    let mut width = plane1.cfg.width;
-    let mut height = plane1.cfg.height;
+    let mut width = plane1.width();
+    let mut height = plane1.height();
     let mut plane1 = plane_to_vec(plane1);
     let mut plane2 = plane_to_vec(plane2);
 

--- a/av_metrics/src/video/ssim.rs
+++ b/av_metrics/src/video/ssim.rs
@@ -480,7 +480,11 @@ fn build_gaussian_kernel(sigma: f64, max_len: usize, kernel_weight: usize) -> Ve
 }
 
 fn plane_to_vec<T: Pixel>(input: &Plane<T>) -> Vec<u32> {
-    input.data.iter().map(|pix| u32::cast_from(*pix)).collect()
+    input
+        .data()
+        .iter()
+        .map(|&pix| u32::from(pix.into()))
+        .collect()
 }
 
 // This acts differently from downscaling a plane, and is what

--- a/av_metrics_decoders/Cargo.toml
+++ b/av_metrics_decoders/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rust-av/av-metrics"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.103"
 av-metrics = "0.9"
 y4m = { version = "0.8", optional = true }
 
@@ -18,10 +18,10 @@ version = "0.5"
 optional = true
 
 [dependencies.ffmpeg-the-third]
-version = "4.0"
+version = "5.0"
 optional = true
 default-features = false
-features = ["codec", "format", "non-exhaustive-enums"]
+features = ["codec", "format"]
 
 [features]
 vapoursynth = ["dep:vapoursynth"]

--- a/av_metrics_decoders/Cargo.toml
+++ b/av_metrics_decoders/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/rust-av/av-metrics"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
+av-metrics = { workspace = true }
 anyhow = "1.0.103"
-av-metrics = "0.9"
 y4m = { version = "0.8", optional = true }
 
 [dependencies.vapoursynth]

--- a/av_metrics_decoders/src/ffmpeg.rs
+++ b/av_metrics_decoders/src/ffmpeg.rs
@@ -27,6 +27,8 @@ pub struct FfmpegDecoder {
 impl FfmpegDecoder {
     /// Initialize a new FFMpeg decoder for a given input file
     pub fn new<P: AsRef<Path>>(input: P) -> Result<Self, String> {
+        use ffmpeg::format::Pixel as PixFmt;
+
         ffmpeg::init().map_err(|e| e.to_string())?;
 
         let input_ctx = format::input(&input).map_err(|e| e.to_string())?;
@@ -50,43 +52,39 @@ impl FfmpegDecoder {
                 width: decoder.width() as usize,
                 height: decoder.height() as usize,
                 bit_depth: match decoder.format() {
-                    format::pixel::Pixel::YUV420P
-                    | format::pixel::Pixel::YUV422P
-                    | format::pixel::Pixel::YUV444P
-                    | format::pixel::Pixel::YUVJ420P
-                    | format::pixel::Pixel::YUVJ422P
-                    | format::pixel::Pixel::YUVJ444P => 8,
-                    format::pixel::Pixel::YUV420P10LE
-                    | format::pixel::Pixel::YUV422P10LE
-                    | format::pixel::Pixel::YUV444P10LE => 10,
-                    format::pixel::Pixel::YUV420P12LE
-                    | format::pixel::Pixel::YUV422P12LE
-                    | format::pixel::Pixel::YUV444P12LE => 12,
-                    _ => {
-                        return Err(format!("Unsupported pixel format {:?}", decoder.format()));
+                    PixFmt::YUV420P
+                    | PixFmt::YUV422P
+                    | PixFmt::YUV444P
+                    | PixFmt::YUVJ420P
+                    | PixFmt::YUVJ422P
+                    | PixFmt::YUVJ444P => 8,
+                    PixFmt::YUV420P10LE | PixFmt::YUV422P10LE | PixFmt::YUV444P10LE => 10,
+                    PixFmt::YUV420P12LE | PixFmt::YUV422P12LE | PixFmt::YUV444P12LE => 12,
+                    fmt => {
+                        return Err(format!("Unsupported pixel format {fmt:?}"));
                     }
                 },
                 chroma_sampling: match decoder.format() {
-                    format::pixel::Pixel::YUV420P
-                    | format::pixel::Pixel::YUVJ420P
-                    | format::pixel::Pixel::YUV420P10LE
-                    | format::pixel::Pixel::YUV420P12LE => ChromaSampling::Cs420,
-                    format::pixel::Pixel::YUV422P
-                    | format::pixel::Pixel::YUVJ422P
-                    | format::pixel::Pixel::YUV422P10LE
-                    | format::pixel::Pixel::YUV422P12LE => ChromaSampling::Cs422,
-                    format::pixel::Pixel::YUV444P
-                    | format::pixel::Pixel::YUVJ444P
-                    | format::pixel::Pixel::YUV444P10LE
-                    | format::pixel::Pixel::YUV444P12LE => ChromaSampling::Cs444,
-                    _ => {
-                        return Err(format!("Unsupported pixel format {:?}", decoder.format()));
+                    PixFmt::YUV420P
+                    | PixFmt::YUVJ420P
+                    | PixFmt::YUV420P10LE
+                    | PixFmt::YUV420P12LE => ChromaSubsampling::Yuv420,
+                    PixFmt::YUV422P
+                    | PixFmt::YUVJ422P
+                    | PixFmt::YUV422P10LE
+                    | PixFmt::YUV422P12LE => ChromaSubsampling::Yuv422,
+                    PixFmt::YUV444P
+                    | PixFmt::YUVJ444P
+                    | PixFmt::YUV444P10LE
+                    | PixFmt::YUV444P12LE => ChromaSubsampling::Yuv444,
+                    fmt => {
+                        return Err(format!("Unsupported pixel format {fmt:?}"));
                     }
                 },
                 chroma_sample_position: match decoder.format() {
-                    format::pixel::Pixel::YUV422P
-                    | format::pixel::Pixel::YUV422P10LE
-                    | format::pixel::Pixel::YUV422P12LE => ChromaSamplePosition::Vertical,
+                    PixFmt::YUV422P | PixFmt::YUV422P10LE | PixFmt::YUV422P12LE => {
+                        ChromaSamplePosition::Vertical
+                    }
                     _ => ChromaSamplePosition::Colocated,
                 },
                 time_base: Rational::new(
@@ -105,23 +103,23 @@ impl FfmpegDecoder {
     }
 
     fn decode_frame<T: Pixel>(&self, decoded: &frame::Video) -> Frame<T> {
-        let mut f: Frame<T> = Frame::new_with_padding(
-            self.video_details.width,
-            self.video_details.height,
-            self.video_details.chroma_sampling,
-            0,
-        );
         let width = self.video_details.width;
         let height = self.video_details.height;
+        let chroma_sampling = self.video_details.chroma_sampling;
         let bit_depth = self.video_details.bit_depth;
+
+        let mut f: Frame<T> = FrameBuilder::new(width, height, chroma_sampling, bit_depth as u8)
+            .build()
+            .expect("can build frame");
         let bytes = if bit_depth > 8 { 2 } else { 1 };
-        let (chroma_width, _) = self
-            .video_details
-            .chroma_sampling
-            .get_chroma_dimensions(width, height);
-        f.planes[0].copy_from_raw_u8(decoded.data(0), width * bytes, bytes);
+        let (chroma_width, _) = chroma_sampling
+            .chroma_dimensions(width, height)
+            .expect("has chroma dimensions");
+        f.y_plane
+            .copy_from_u8_slice_with_stride(decoded.data(0), width * bytes)
+            .expect("can copy data");
         convert_chroma_data(
-            &mut f.planes[1],
+            f.plane_mut(1).expect("has plane 1"),
             self.video_details.chroma_sample_position,
             bit_depth,
             decoded.data(1),
@@ -129,7 +127,7 @@ impl FfmpegDecoder {
             bytes,
         );
         convert_chroma_data(
-            &mut f.planes[2],
+            f.plane_mut(2).expect("has plane 2"),
             self.video_details.chroma_sample_position,
             bit_depth,
             decoded.data(2),

--- a/av_metrics_decoders/src/ffmpeg.rs
+++ b/av_metrics_decoders/src/ffmpeg.rs
@@ -31,7 +31,7 @@ impl FfmpegDecoder {
 
         ffmpeg::init().map_err(|e| e.to_string())?;
 
-        let input_ctx = format::input(&input).map_err(|e| e.to_string())?;
+        let input_ctx = format::input(input.as_ref()).map_err(|e| e.to_string())?;
         let input = input_ctx
             .streams()
             .best(Type::Video)

--- a/av_metrics_decoders/src/lib.rs
+++ b/av_metrics_decoders/src/lib.rs
@@ -34,4 +34,4 @@ mod vapoursynth;
 pub use crate::vapoursynth::{VapoursynthDecoder, VapoursynthDecoderPlugin};
 
 pub use av_metrics::video::decode::{Decoder, VideoDetails};
-pub use av_metrics::video::{CastFromPrimitive, ChromaSampling, Frame, Pixel, Plane};
+pub use av_metrics::video::{ChromaSubsampling, Frame, Pixel, Plane};

--- a/av_metrics_decoders/src/vapoursynth.rs
+++ b/av_metrics_decoders/src/vapoursynth.rs
@@ -1,7 +1,7 @@
 use anyhow::{ensure, Result};
 use av_metrics::video::{
     decode::{Decoder, Rational, VideoDetails},
-    ChromaSampling,
+    ChromaSubsampling,
 };
 use std::{
     mem::{size_of, transmute},
@@ -124,73 +124,78 @@ impl Decoder for VapoursynthDecoder {
             panic!("Unsupported bit depth");
         }
 
-        let mut f: av_metrics::video::Frame<T> = av_metrics::video::Frame::new_with_padding(
+        let mut f: av_metrics::video::Frame<T> = av_metrics::video::FrameBuilder::new(
             details.width,
             details.height,
             details.chroma_sampling,
-            0,
-        );
+            details.bit_depth as u8,
+        )
+        .build()
+        .expect("can build frame");
 
         {
-            let frame = self.get_node().unwrap().get_frame(self.cur_frame);
-            if frame.is_err() {
+            let Ok(frame) = self.get_node().unwrap().get_frame(self.cur_frame) else {
                 return None;
-            }
-            let frame = frame.unwrap();
+            };
+
             match size_of::<T>() {
                 1 => {
-                    for (out_row, in_row) in f.planes[0]
-                        .rows_iter_mut()
+                    for (out_row, in_row) in f
+                        .y_plane
+                        .rows_mut()
                         .zip((0..details.height).map(|y| frame.plane_row::<u8>(0, y)))
                     {
                         // SAFETY: We know that `T` is `u8` here.
                         out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                     }
-                    if details.chroma_sampling != ChromaSampling::Cs400 {
-                        for (out_row, in_row) in f.planes[1].rows_iter_mut().zip(
-                            (0..(details.height
-                                >> details.chroma_sampling.get_decimation().unwrap().1))
-                                .map(|y| frame.plane_row::<u8>(1, y)),
-                        ) {
+                    if let Some((_, y_ratio)) = details.chroma_sampling.subsample_ratio() {
+                        for (out_row, in_row) in
+                            f.plane_mut(1).expect("has plane 1").rows_mut().zip(
+                                (0..(details.height / usize::from(y_ratio.get())))
+                                    .map(|y| frame.plane_row::<u8>(1, y)),
+                            )
+                        {
                             // SAFETY: We know that `T` is `u8` here.
                             out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                         }
-                    }
-                    if details.chroma_sampling != ChromaSampling::Cs400 {
-                        for (out_row, in_row) in f.planes[2].rows_iter_mut().zip(
-                            (0..(details.height
-                                >> details.chroma_sampling.get_decimation().unwrap().1))
-                                .map(|y| frame.plane_row::<u8>(2, y)),
-                        ) {
+
+                        for (out_row, in_row) in
+                            f.plane_mut(2).expect("has plane 2").rows_mut().zip(
+                                (0..(details.height / usize::from(y_ratio.get())))
+                                    .map(|y| frame.plane_row::<u8>(2, y)),
+                            )
+                        {
                             // SAFETY: We know that `T` is `u8` here.
                             out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                         }
                     }
                 }
                 2 => {
-                    for (out_row, in_row) in f.planes[0]
-                        .rows_iter_mut()
+                    for (out_row, in_row) in f
+                        .y_plane
+                        .rows_mut()
                         .zip((0..details.height).map(|y| frame.plane_row::<u16>(0, y)))
                     {
                         // SAFETY: We know that `T` is `u16` here.
                         out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                     }
-                    if details.chroma_sampling != ChromaSampling::Cs400 {
-                        for (out_row, in_row) in f.planes[1].rows_iter_mut().zip(
-                            (0..(details.height
-                                >> details.chroma_sampling.get_decimation().unwrap().1))
-                                .map(|y| frame.plane_row::<u16>(1, y)),
-                        ) {
+                    if let Some((_, y_ratio)) = details.chroma_sampling.subsample_ratio() {
+                        for (out_row, in_row) in
+                            f.plane_mut(1).expect("has plane 1").rows_mut().zip(
+                                (0..(details.height / usize::from(y_ratio.get())))
+                                    .map(|y| frame.plane_row::<u16>(1, y)),
+                            )
+                        {
                             // SAFETY: We know that `T` is `u16` here.
                             out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                         }
-                    }
-                    if details.chroma_sampling != ChromaSampling::Cs400 {
-                        for (out_row, in_row) in f.planes[2].rows_iter_mut().zip(
-                            (0..(details.height
-                                >> details.chroma_sampling.get_decimation().unwrap().1))
-                                .map(|y| frame.plane_row::<u16>(2, y)),
-                        ) {
+
+                        for (out_row, in_row) in
+                            f.plane_mut(2).expect("has plane 2").rows_mut().zip(
+                                (0..(details.height / usize::from(y_ratio.get())))
+                                    .map(|y| frame.plane_row::<u16>(2, y)),
+                            )
+                        {
                             // SAFETY: We know that `T` is `u16` here.
                             out_row[..in_row.len()].copy_from_slice(unsafe { transmute(in_row) });
                         }
@@ -217,10 +222,10 @@ impl Decoder for VapoursynthDecoder {
             format.color_family(),
             format.sub_sampling_w() + format.sub_sampling_h(),
         ) {
-            (ColorFamily::Gray, _) => ChromaSampling::Cs400,
-            (_, 0) => ChromaSampling::Cs444,
-            (_, 1) => ChromaSampling::Cs422,
-            _ => ChromaSampling::Cs420,
+            (ColorFamily::Gray, _) => ChromaSubsampling::Monochrome,
+            (_, 0) => ChromaSubsampling::Yuv444,
+            (_, 1) => ChromaSubsampling::Yuv422,
+            _ => ChromaSubsampling::Yuv420,
         };
         VideoDetails {
             width: res.width,

--- a/av_metrics_decoders/src/y4m.rs
+++ b/av_metrics_decoders/src/y4m.rs
@@ -10,18 +10,18 @@ pub struct Y4MDecoder<R: Read + Send> {
 }
 
 /// Function to map y4m color space
-fn map_y4m_color_space(color_space: y4m::Colorspace) -> (ChromaSampling, ChromaSamplePosition) {
+fn map_y4m_color_space(color_space: y4m::Colorspace) -> (ChromaSubsampling, ChromaSamplePosition) {
     use av_metrics::video::ChromaSamplePosition::*;
-    use av_metrics::video::ChromaSampling::*;
+    use av_metrics::video::ChromaSubsampling::*;
     use y4m::Colorspace::*;
     match color_space {
-        Cmono | Cmono12 => (Cs400, Unknown),
-        C420jpeg => (Cs420, Bilateral),
-        C420paldv => (Cs420, Interpolated),
-        C420mpeg2 => (Cs420, Vertical),
-        C420 | C420p10 | C420p12 => (Cs420, Colocated),
-        C422 | C422p10 | C422p12 => (Cs422, Vertical),
-        C444 | C444p10 | C444p12 => (Cs444, Colocated),
+        Cmono | Cmono12 => (Monochrome, Unknown),
+        C420jpeg => (Yuv420, Bilateral),
+        C420paldv => (Yuv420, Interpolated),
+        C420mpeg2 => (Yuv420, Vertical),
+        C420 | C420p10 | C420p12 => (Yuv420, Colocated),
+        C422 | C422p10 | C422p12 => (Yuv422, Vertical),
+        C444 | C444p10 | C444p12 => (Yuv444, Colocated),
         _ => unimplemented!(),
     }
 }

--- a/av_metrics_decoders/src/y4m.rs
+++ b/av_metrics_decoders/src/y4m.rs
@@ -75,12 +75,19 @@ where
         let height = self.inner.get_height();
         let bytes = self.inner.get_bytes_per_sample();
         self.inner.read_frame().ok().map(|frame| {
-            let mut f: Frame<T> = Frame::new_with_padding(width, height, chroma_sampling, 0);
+            let mut f: Frame<T> =
+                FrameBuilder::new(width, height, chroma_sampling, bit_depth as u8)
+                    .build()
+                    .expect("can build frame");
 
-            let (chroma_width, _) = chroma_sampling.get_chroma_dimensions(width, height);
-            f.planes[0].copy_from_raw_u8(frame.get_y_plane(), width * bytes, bytes);
+            let (chroma_width, _) = chroma_sampling
+                .chroma_dimensions(width, height)
+                .expect("can subsample");
+            f.y_plane
+                .copy_from_u8_slice_with_stride(frame.get_y_plane(), width * bytes)
+                .expect("can copy");
             convert_chroma_data(
-                &mut f.planes[1],
+                f.plane_mut(1).expect("has plane 1"),
                 chroma_sample_pos,
                 bit_depth,
                 frame.get_u_plane(),
@@ -88,7 +95,7 @@ where
                 bytes,
             );
             convert_chroma_data(
-                &mut f.planes[2],
+                f.plane_mut(2).expect("has plane 2"),
                 chroma_sample_pos,
                 bit_depth,
                 frame.get_v_plane(),

--- a/av_metrics_tests/Cargo.toml
+++ b/av_metrics_tests/Cargo.toml
@@ -7,8 +7,8 @@ repository = "https://github.com/rust-av/av-metrics"
 publish = false
 
 [dependencies]
-av-metrics = { version = "0.9", features = ["serde"] }
-av-metrics-decoders = "0.3.1"
+av-metrics = { workspace = true, features = ["serde"] }
+av-metrics-decoders = { workspace = true }
 
 [features]
 default = ["y4m"]

--- a/av_metrics_tool/Cargo.toml
+++ b/av_metrics_tool/Cargo.toml
@@ -12,8 +12,8 @@ include = ["src/**/*", "LICENSE"]
 av-metrics = { version = "0.9", features = ["serde"] }
 av-metrics-decoders = "0.3.2"
 clap = "4"
-console = "0.15.0"
-indicatif = "0.17.1"
+console = "0.16"
+indicatif = "0.18"
 serde = "1"
 serde_json = "1"
 

--- a/av_metrics_tool/Cargo.toml
+++ b/av_metrics_tool/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/rust-av/av-metrics"
 include = ["src/**/*", "LICENSE"]
 
 [dependencies]
-av-metrics = { version = "0.9", features = ["serde"] }
-av-metrics-decoders = "0.3.2"
+av-metrics = { workspace = true, features = ["serde"] }
+av-metrics-decoders = { workspace = true }
 clap = "4"
 console = "0.16"
 indicatif = "0.18"


### PR DESCRIPTION
Requires #311.

- bump some outdated dependencies
- add rust-version field to package manifests
- use proper `[workspace.dependencies]` instead of `[patch]`